### PR TITLE
KAFKA-9548 Added RemoteStorageManager, RemoteLogMetadataManager and its related public classes.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/TopicIdPartition.java
+++ b/clients/src/main/java/org/apache/kafka/common/TopicIdPartition.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * This represents unique identifier with topic id for a topic partition. No two topics will have unique id even though
+ * they have same name. This makes sure that recreated topics with the same name will always have unique topic
+ * identifiers.
+ */
+public class TopicIdPartition {
+
+    private final UUID topicId;
+    private final TopicPartition topicPartition;
+
+    public TopicIdPartition(UUID topicId, TopicPartition topicPartition) {
+        Objects.requireNonNull(topicId, "topicId can not be null");
+        Objects.requireNonNull(topicPartition, "topicPartition can not be null");
+        this.topicId = topicId;
+        this.topicPartition = topicPartition;
+    }
+
+    public UUID topicId() {
+        return topicId;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TopicIdPartition that = (TopicIdPartition) o;
+        return Objects.equals(topicId, that.topicId) &&
+                Objects.equals(topicPartition, that.topicPartition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicId, topicPartition);
+    }
+
+    @Override
+    public String toString() {
+        return "TopicIdPartition{" +
+                "id=" + topicId +
+                ", topicPartition=" + topicPartition +
+                '}';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/LogSegmentData.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/LogSegmentData.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+
+/**
+ * This represents all the required data and indexes for a specific log segment that needs to be stored in the remote
+ * storage. This is passed with {@link RemoteStorageManager#copyLogSegment(RemoteLogSegmentMetadata, LogSegmentData)}
+ * while copying a specific log segment to the remote storage.
+ */
+@InterfaceStability.Evolving
+public class LogSegmentData {
+
+    private final File logSegment;
+    private final File offsetIndex;
+    private final File timeIndex;
+    private final File txnIndex;
+    private final File producerIdSnapshotIndex;
+    private final ByteBuffer leaderEpochIndex;
+
+    /**
+     * Creates a LogSegmentData instance with data and indexes.
+     *
+     * @param logSegment              actual log segment file.
+     * @param offsetIndex             offset index file
+     * @param timeIndex               time index file
+     * @param txnIndex                transaction index file
+     * @param producerIdSnapshotIndex producer-id-snapshot until this segment
+     * @param leaderEpochIndex        leader-epoch-index until this segment.
+     */
+    public LogSegmentData(File logSegment, File offsetIndex, File timeIndex, File txnIndex,
+                          File producerIdSnapshotIndex, ByteBuffer leaderEpochIndex) {
+        this.logSegment = logSegment;
+        this.offsetIndex = offsetIndex;
+        this.timeIndex = timeIndex;
+        this.txnIndex = txnIndex;
+        this.producerIdSnapshotIndex = producerIdSnapshotIndex;
+        this.leaderEpochIndex = leaderEpochIndex;
+    }
+
+    /**
+     * @return Log segment file of this segment.
+     */
+    public File logSegment() {
+        return logSegment;
+    }
+
+    /**
+     * @return Offset index file.
+     */
+    public File offsetIndex() {
+        return offsetIndex;
+    }
+
+    /**
+     * @return Time index file of this segment.
+     */
+    public File timeIndex() {
+        return timeIndex;
+    }
+
+    /**
+     * @return Transaction index file of this segment.
+     */
+    public File txnIndex() {
+        return txnIndex;
+    }
+
+    /**
+     * @return Producer-id snapshot file until this segment.
+     */
+    public File producerIdSnapshotIndex() {
+        return producerIdSnapshotIndex;
+    }
+
+    /**
+     * @return Leader epoch index until this segment.
+     */
+    public ByteBuffer leaderEpochIndex() {
+        return leaderEpochIndex;
+    }
+
+    @Override
+    public String toString() {
+        return "LogSegmentData{" +
+                "logSegment=" + logSegment +
+                ", offsetIndex=" + offsetIndex +
+                ", timeIndex=" + timeIndex +
+                ", txnIndex=" + txnIndex +
+                ", producerIdSnapshotIndex=" + producerIdSnapshotIndex +
+                ", leaderEpochIndex=" + leaderEpochIndex +
+                '}';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogMetadataManager.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * This interface provides storing and fetching remote log segment metadata with strongly consistent semantics.
+ * <p>
+ * This class can be plugged in to Kafka cluster by adding the implementation class as
+ * <code>remote.log.metadata.manager.class.name</code> property value. There is an inbuilt implementation backed by
+ * topic storage in the local cluster. This is used as the default implementation if
+ * remote.log.metadata.manager.class.name is not configured.
+ * </p>
+ * <p>
+ * <code>remote.log.metadata.manager.class.path</code> property is about the class path of the RemoteLogStorageManager
+ * implementation. If specified, the RemoteLogStorageManager implementation and its dependent libraries will be loaded
+ * by a dedicated classloader which searches this class path before the Kafka broker class path. The syntax of this
+ * parameter is same with the standard Java class path string.
+ * </p>
+ * <p>
+ * <code>remote.log.metadata.manager.listener.name</code> property is about listener name of the local broker to which
+ * it should get connected if needed by RemoteLogMetadataManager implementation. When this is configured all other
+ * required properties can be passed as properties with prefix of 'remote.log.metadata.manager.listener.
+ * </p>
+ * "cluster.id", "broker.id" and all other properties prefixed with "remote.log.metadata." are passed when
+ * {@link #configure(Map)} is invoked on this instance.
+ * <p>
+ */
+@InterfaceStability.Evolving
+public interface RemoteLogMetadataManager extends Configurable, Closeable {
+
+    /**
+     * Stores {@link }RemoteLogSegmentMetadata} with the containing {@link }RemoteLogSegmentId} into {@link RemoteLogMetadataManager}.
+     * <p>
+     * RemoteLogSegmentMetadata is identified by RemoteLogSegmentId.
+     *
+     * @param remoteLogSegmentMetadata metadata about the remote log segment.
+     * @throws RemoteStorageException if there are any storage related errors occurred.
+     */
+    void putRemoteLogSegmentMetadata(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException;
+
+    /**
+     * {@link RemoteLogSegmentMetadata} is updated with the new state based on the life cycle of the segment. It can go
+     * through the below state transitions.
+     * <p>
+     * <pre>
+     * +---------------------+            +----------------------+
+     * |COPY_SEGMENT_STARTED |----------->|COPY_SEGMENT_FINISHED |
+     * +-------------------+-+            +--+-------------------+
+     *                     |                 |
+     *                     |                 |
+     *                     v                 v
+     *                  +--+-----------------+-+
+     *                  |DELETE_SEGMENT_STARTED|
+     *                  +-----------+----------+
+     *                              |
+     *                              |
+     *                              v
+     *                  +-----------+-----------+
+     *                  |DELETE_SEGMENT_FINISHED|
+     *                  +-----------------------+
+     * </pre>
+     * <p>
+     * {@link RemoteLogSegmentState#COPY_SEGMENT_STARTED} - This state indicates that the segment copying to remote storage is started but not yet finished.
+     * {@link RemoteLogSegmentState#COPY_SEGMENT_FINISHED} - This state indicates that the segment copying to remote storage is finished.
+     * <br>
+     * The leader broker copies the log segments to the remote storage and puts the remote log segment metadata with the
+     * state as “COPY_SEGMENT_STARTED” and updates the state as “COPY_SEGMENT_FINISHED” once the copy is successful.
+     * <p></p>
+     * {@link RemoteLogSegmentState#DELETE_SEGMENT_STARTED} - This state indicates that the segment deletion is started but not yet finished.
+     * {@link RemoteLogSegmentState#DELETE_SEGMENT_FINISHED} - This state indicates that the segment is deleted successfully.
+     * <br>
+     * Leader partitions publish both the above delete segment events when remote log retention is reached for the
+     * respective segments. Remote Partition Removers also publish these events when a segment is deleted as part of
+     * the remote partition deletion.
+     *
+     * @param remoteLogSegmentMetadataUpdate update of the remote log segment metadata.
+     * @throws RemoteStorageException if there are any storage related errors occurred.
+     */
+    void updateRemoteLogSegmentMetadata(RemoteLogSegmentMetadataUpdate remoteLogSegmentMetadataUpdate) throws RemoteStorageException;
+
+    /**
+     * Returns {@link RemoteLogSegmentMetadata} if it exists for the given topic partition containing the offset with
+     * the given leader-epoch for the offset, else returns {@link Optional#empty()}.
+     *
+     * @param topicIdPartition topic partition
+     * @param offset           offset
+     * @param epochForOffset   leader epoch for the given offset
+     * @return the requested remote log segment metadata if it exists.
+     * @throws RemoteStorageException if there are any storage related errors occurred.
+     */
+    Optional<RemoteLogSegmentMetadata> remoteLogSegmentMetadata(TopicIdPartition topicIdPartition, long offset, int epochForOffset)
+            throws RemoteStorageException;
+
+    /**
+     * Returns the highest log offset of topic partition for the given leader epoch in remote storage. This is used by
+     * remote log management subsystem to know upto which offset the segments have been copied to remote storage for
+     * a given leader epoch.
+     *
+     * @param topicIdPartition topic partition
+     * @param leaderEpoch      leader epoch
+     * @return the requested highest log offset if exists.
+     * @throws RemoteStorageException if there are any storage related errors occurred.
+     */
+    Optional<Long> highestLogOffset(TopicIdPartition topicIdPartition, int leaderEpoch) throws RemoteStorageException;
+
+    /**
+     * Update the delete partition state of a topic partition in metadata storage. Controller invokes this method with
+     * {@link RemotePartitionDeleteMetadata} having state as {@link RemotePartitionDeleteState#DELETE_PARTITION_MARKED}.
+     * So, remote partition removers can act on this event to clean the respective remote log segments of the partition.
+     * <p><br>
+     * Incase of default RLMM implementation, remote partition remover processes {@link RemotePartitionDeleteState#DELETE_PARTITION_MARKED}
+     * <ul>
+     * <li> sends an event with state as {@link RemotePartitionDeleteState#DELETE_PARTITION_STARTED}
+     * <li> gets all the remote log segments and deletes them.
+     * <li> sends an event with state as {@link RemotePartitionDeleteState#DELETE_PARTITION_FINISHED} once all the remote log segments are
+     * deleted.
+     * </ul>
+     *
+     * @param remotePartitionDeleteMetadata update on delete state of a partition.
+     * @throws RemoteStorageException if there are any storage related errors occurred.
+     */
+    void updateRemotePartitionDeleteMetadata(RemotePartitionDeleteMetadata remotePartitionDeleteMetadata) throws RemoteStorageException;
+
+    /**
+     * List all the remote log segment metadata of the given topicIdPartition.
+     * <p>
+     * Remote Partition Removers uses this method to fetch all the segments for a given topic partition, so that they
+     * can delete them.
+     *
+     * @return Iterator of remote segments, sorted by start offset in ascending order.
+     */
+    Iterator<RemoteLogSegmentMetadata> listRemoteLogSegments(TopicIdPartition topicIdPartition);
+
+    /**
+     * Returns iterator of remote log segment metadata, sorted by {@link RemoteLogSegmentMetadata#startOffset()} in
+     * ascending order which contains the given leader epoch. This is used by remote log retention management subsystem
+     * to fetch the segment metadata for a given leader epoch.
+     *
+     * @param topicIdPartition topic partition
+     * @param leaderEpoch      leader epoch
+     * @return Iterator of remote segments, sorted by start offset in ascending order.
+     */
+    Iterator<RemoteLogSegmentMetadata> listRemoteLogSegments(TopicIdPartition topicIdPartition, long leaderEpoch);
+
+    /**
+     * This method is invoked only when there are changes in leadership of the topic partitions that this broker is
+     * responsible for.
+     *
+     * @param leaderPartitions   partitions that have become leaders on this broker.
+     * @param followerPartitions partitions that have become followers on this broker.
+     */
+    void onPartitionLeadershipChanges(Set<TopicIdPartition> leaderPartitions, Set<TopicIdPartition> followerPartitions);
+
+    /**
+     * This method is invoked only when the topic partitions are stopped on this broker. This can happen when a
+     * partition is emigrated to other broker or a partition is deleted.
+     *
+     * @param partitions topic partitions that have been stopped.
+     */
+    void onStopPartitions(Set<TopicIdPartition> partitions);
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentId.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentId.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * This class represents a universally unique identifier associated to a topic partition's log segment. This will be
+ * regenerated for every attempt of copying a specific log segment in {@link RemoteStorageManager#copyLogSegment(RemoteLogSegmentMetadata, LogSegmentData)}.
+ * Once it is stored in remote storage, it is used to access that segment later from remote log metadata storage.
+ */
+@InterfaceStability.Evolving
+public class RemoteLogSegmentId implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final TopicIdPartition topicIdPartition;
+    private final UUID id;
+
+    public RemoteLogSegmentId(TopicIdPartition topicIdPartition, UUID id) {
+        this.topicIdPartition = requireNonNull(topicIdPartition);
+        this.id = requireNonNull(id);
+    }
+
+    /**
+     * @return TopicIdPartition of this remote log segment.
+     */
+    public TopicIdPartition topicIdPartition() {
+        return topicIdPartition;
+    }
+
+    /**
+     * @return Universally Unique Id of this remote log segment.
+     */
+    public UUID id() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteLogSegmentId{" +
+                "topicIdPartition=" + topicIdPartition +
+                ", id=" + id +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RemoteLogSegmentId that = (RemoteLogSegmentId) o;
+        return Objects.equals(topicIdPartition, that.topicIdPartition) && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicIdPartition, id);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * It describes the metadata about a topic partition's remote log segment in the remote storage. This is uniquely
+ * represented with {@link RemoteLogSegmentId}.
+ */
+@InterfaceStability.Evolving
+public class RemoteLogSegmentMetadata implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Universally unique remote log segment id.
+     */
+    private final RemoteLogSegmentId remoteLogSegmentId;
+
+    /**
+     * Start offset of this segment.
+     */
+    private final long startOffset;
+
+    /**
+     * End offset of this segment.
+     */
+    private final long endOffset;
+
+    /**
+     * Current leader epoch of this segment.
+     */
+    private final int leaderEpoch;
+
+    /**
+     * Maximum timestamp in the segment
+     */
+    private final long maxTimestamp;
+
+    /**
+     * Epoch time at which the respective {@link #state} is set.
+     */
+    private final long eventTimestamp;
+
+    /**
+     * LeaderEpoch vs offset for messages with in this segment.
+     */
+    private final Map<Integer, Long> segmentLeaderEpochs;
+
+    /**
+     * Size of the segment in bytes.
+     */
+    private final int segmentSizeInBytes;
+
+    /**
+     * It indicates the state in which the action is executed on this segment.
+     */
+    private final RemoteLogSegmentState state;
+
+    /**
+     * Creates an instance with the given metadata of remote log segment.
+     *
+     * @param remoteLogSegmentId  Universally unique remote log segment id.
+     * @param startOffset         Start offset of this segment.
+     * @param endOffset           End offset of this segment.
+     * @param maxTimestamp        Maximum timestamp in this segment
+     * @param leaderEpoch         Leader epoch of the broker.
+     * @param eventTimestamp      Epoch time at which the remote log segment is copied to the remote tier storage.
+     * @param segmentSizeInBytes  Size of this segment in bytes.
+     * @param state               State of the respective segment of remoteLogSegmentId.
+     * @param segmentLeaderEpochs leader epochs occurred with in this segment
+     */
+    public RemoteLogSegmentMetadata(RemoteLogSegmentId remoteLogSegmentId, long startOffset, long endOffset,
+                                    long maxTimestamp, int leaderEpoch, long eventTimestamp,
+                                    int segmentSizeInBytes, RemoteLogSegmentState state, Map<Integer, Long> segmentLeaderEpochs) {
+        this.remoteLogSegmentId = remoteLogSegmentId;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+        this.leaderEpoch = leaderEpoch;
+        this.maxTimestamp = maxTimestamp;
+        this.eventTimestamp = eventTimestamp;
+        this.segmentLeaderEpochs = segmentLeaderEpochs;
+        this.state = state;
+        this.segmentSizeInBytes = segmentSizeInBytes;
+    }
+
+    /**
+     * @return unique id of this segment.
+     */
+    public RemoteLogSegmentId remoteLogSegmentId() {
+        return remoteLogSegmentId;
+    }
+
+    /**
+     * @return Start offset of this segment(inclusive).
+     */
+    public long startOffset() {
+        return startOffset;
+    }
+
+    /**
+     * @return End offset of this segment(inclusive).
+     */
+    public long endOffset() {
+        return endOffset;
+    }
+
+    /**
+     * @return Epoch time at which this event is occurred.
+     */
+    public long eventTimestamp() {
+        return eventTimestamp;
+    }
+
+    /**
+     * @return Total size of this segment in bytes.
+     */
+    public int segmentSizeInBytes() {
+        return segmentSizeInBytes;
+    }
+
+    /**
+     * @return Maximum timestamp of a record with in this segment.
+     */
+    public long maxTimestamp() {
+        return maxTimestamp;
+    }
+
+    /**
+     * @return Map of leader epoch vs offset for the records available in this segment.
+     */
+    public Map<Integer, Long> segmentLeaderEpochs() {
+        return segmentLeaderEpochs;
+    }
+
+    /**
+     * @return Current leader epoch of this segment.
+     */
+    public int leaderEpoch() {
+        return leaderEpoch;
+    }
+
+    /**
+     * Returns the current state of this remote log segment. It can be any of the below
+     * <ul>
+     *     {@link RemoteLogSegmentState#COPY_SEGMENT_STARTED}
+     *     {@link RemoteLogSegmentState#COPY_SEGMENT_FINISHED}
+     *     {@link RemoteLogSegmentState#DELETE_SEGMENT_STARTED}
+     *     {@link RemoteLogSegmentState#DELETE_SEGMENT_FINISHED}
+     * </ul>
+     */
+    public RemoteLogSegmentState state() {
+        return state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RemoteLogSegmentMetadata that = (RemoteLogSegmentMetadata) o;
+        return startOffset == that.startOffset && endOffset == that.endOffset && leaderEpoch == that.leaderEpoch && maxTimestamp == that.maxTimestamp && eventTimestamp == that.eventTimestamp && segmentSizeInBytes == that.segmentSizeInBytes && Objects.equals(remoteLogSegmentId, that.remoteLogSegmentId) && Objects.equals(segmentLeaderEpochs, that.segmentLeaderEpochs) && state == that.state;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(remoteLogSegmentId, startOffset, endOffset, leaderEpoch, maxTimestamp, eventTimestamp, segmentLeaderEpochs, segmentSizeInBytes, state);
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteLogSegmentMetadata{" +
+                "remoteLogSegmentId=" + remoteLogSegmentId +
+                ", startOffset=" + startOffset +
+                ", endOffset=" + endOffset +
+                ", leaderEpoch=" + leaderEpoch +
+                ", maxTimestamp=" + maxTimestamp +
+                ", eventTimestamp=" + eventTimestamp +
+                ", segmentLeaderEpochs=" + segmentLeaderEpochs +
+                ", segmentSizeInBytes=" + segmentSizeInBytes +
+                ", state=" + state +
+                '}';
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentMetadataUpdate.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentMetadataUpdate.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * It describes the metadata update about the log segment in the remote storage. This is used to update the state of
+ * the remote log segment by using {@link RemoteLogMetadataManager#updateRemoteLogSegmentMetadata(RemoteLogSegmentMetadataUpdate)}.
+ * This also includes the timestamp of this event and leader epoch in which it
+ */
+@InterfaceStability.Evolving
+public class RemoteLogSegmentMetadataUpdate implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Universally unique remote log segment id.
+     */
+    private final RemoteLogSegmentId remoteLogSegmentId;
+
+    /**
+     * Epoch time at which this event is generated.
+     */
+    private final long eventTimestamp;
+
+    /**
+     * It indicates the state in which the action is executed on this segment.
+     */
+    private final RemoteLogSegmentState state;
+
+    /**
+     * @param remoteLogSegmentId  Universally unique remote log segment id.
+     * @param eventTimestamp      Epoch time at which the remote log segment is copied to the remote tier storage.
+     * @param state               state of the remote log segment.
+     */
+    public RemoteLogSegmentMetadataUpdate(RemoteLogSegmentId remoteLogSegmentId,
+                                          long eventTimestamp,
+                                          RemoteLogSegmentState state) {
+        this.remoteLogSegmentId = remoteLogSegmentId;
+        this.eventTimestamp = eventTimestamp;
+        this.state = state;
+    }
+
+    /**
+     * @return Universally unique id of this remote log segment.
+     */
+    public RemoteLogSegmentId remoteLogSegmentId() {
+        return remoteLogSegmentId;
+    }
+
+    /**
+     * @return Epoch time at which this event is generated.
+     */
+    public long eventTimestamp() {
+        return eventTimestamp;
+    }
+
+    /**
+     * It represents the state of the remote log segment. It can be one of the values of {@link RemoteLogSegmentState}.
+     */
+    public RemoteLogSegmentState state() {
+        return state;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RemoteLogSegmentMetadataUpdate that = (RemoteLogSegmentMetadataUpdate) o;
+        return eventTimestamp == that.eventTimestamp && Objects.equals(remoteLogSegmentId, that.remoteLogSegmentId) && state == that.state;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(remoteLogSegmentId, eventTimestamp, state);
+    }
+
+    @Override
+    public String toString() {
+        return "RemoteLogSegmentMetadataUpdate{" +
+                "remoteLogSegmentId=" + remoteLogSegmentId +
+                ", eventTimestamp=" + eventTimestamp +
+                ", state=" + state +
+                '}';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentState.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentState.java
@@ -1,0 +1,73 @@
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+/**
+ * It indicates the state of the remote log segment. This will be based on the action executed on this
+ * segment by the remote log service implementation.
+ * <p>
+ * It goes through the below state transitions.
+ * <p>
+ * <pre>
+ * +---------------------+            +----------------------+
+ * |COPY_SEGMENT_STARTED |----------->|COPY_SEGMENT_FINISHED |
+ * +-------------------+-+            +--+-------------------+
+ *                     |                 |
+ *                     |                 |
+ *                     v                 v
+ *                  +--+-----------------+-+
+ *                  |DELETE_SEGMENT_STARTED|
+ *                  +-----------+----------+
+ *                              |
+ *                              |
+ *                              v
+ *                  +-----------+-----------+
+ *                  |DELETE_SEGMENT_FINISHED|
+ *                  +-----------------------+
+ * </pre>
+ */
+@InterfaceStability.Evolving
+public enum RemoteLogSegmentState {
+
+    /**
+     * This state indicates that the segment copying to remote storage is started but not yet finished.
+     */
+    COPY_SEGMENT_STARTED((byte) 0),
+
+    /**
+     * This state indicates that the segment copying to remote storage is finished.
+     */
+    COPY_SEGMENT_FINISHED((byte) 1),
+
+    /**
+     * This state indicates that the segment deletion is started but not yet finished.
+     */
+    DELETE_SEGMENT_STARTED((byte) 2),
+
+    /**
+     * This state indicates that the segment is deleted successfully.
+     */
+    DELETE_SEGMENT_FINISHED((byte) 3);
+
+    private static final Map<Byte, RemoteLogSegmentState> STATE_TYPES = Collections.unmodifiableMap(
+            Arrays.stream(values()).collect(Collectors.toMap(RemoteLogSegmentState::id, Function.identity())));
+
+    private final byte id;
+
+    RemoteLogSegmentState(byte id) {
+        this.id = id;
+    }
+
+    public byte id() {
+        return id;
+    }
+
+    public static RemoteLogSegmentState forId(byte id) {
+        return STATE_TYPES.get(id);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemotePartitionDeleteMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemotePartitionDeleteMetadata.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * This class represents the metadata about the remote partition. It can be updated with {@link RemoteLogMetadataManager#updateRemotePartitionDeleteMetadata(RemotePartitionDeleteMetadata)}.
+ * Possible state transitions are mentioned at {@link RemotePartitionDeleteState}.
+ */
+@InterfaceStability.Evolving
+public class RemotePartitionDeleteMetadata {
+
+    private final TopicIdPartition topicIdPartition;
+    private final RemotePartitionDeleteState state;
+    private final long eventTimestamp;
+    private final int brokerId;
+
+    public RemotePartitionDeleteMetadata(TopicIdPartition topicIdPartition, RemotePartitionDeleteState state, long eventTimestamp, int brokerId) {
+        Objects.requireNonNull(topicIdPartition);
+        Objects.requireNonNull(state);
+        this.topicIdPartition = topicIdPartition;
+        this.state = state;
+        this.eventTimestamp = eventTimestamp;
+        this.brokerId = brokerId;
+    }
+
+    /**
+     * @return TopicIdPartition for which this event is meant for.
+     */
+    public TopicIdPartition topicIdPartition() {
+        return topicIdPartition;
+    }
+
+    /**
+     * It represents the state of the remote partition. It can be one of the values of {@link RemotePartitionDeleteState}.
+     */
+    public RemotePartitionDeleteState state() {
+        return state;
+    }
+
+    /**
+     * @return Epoch time at which this event is occurred.
+     */
+    public long eventTimestamp() {
+        return eventTimestamp;
+    }
+
+    /**
+     * @return broker id from which this event is generated.
+     */
+    public int brokerId() {
+        return brokerId;
+    }
+
+    @Override
+    public String toString() {
+        return "RemotePartitionDeleteMetadata{" +
+                "topicPartition=" + topicIdPartition +
+                ", state=" + state +
+                ", eventTimestamp=" + eventTimestamp +
+                ", brokerId=" + brokerId +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RemotePartitionDeleteMetadata that = (RemotePartitionDeleteMetadata) o;
+        return eventTimestamp == that.eventTimestamp &&
+                brokerId == that.brokerId &&
+                Objects.equals(topicIdPartition, that.topicIdPartition) &&
+                state == that.state;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicIdPartition, state, eventTimestamp, brokerId);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemotePartitionDeleteState.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemotePartitionDeleteState.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * It indicates the deletion state of the remote topic partition. This will be based on the action executed on this
+ * partition by the remote log service implementation.
+ * State transitions are mentioned below.
+ * <P>
+ * <PRE>
+ *        +-------------------------+
+ *        |DELETE_PARTITION_MARKED  |
+ *        +-----------+-------------+
+ *                    |
+ *                    |
+ *        +-----------v--------------+
+ *        |DELETE_PARTITION_STARTED  |
+ *        +-----------+--------------+
+ *                    |
+ *                    |
+ *        +-----------v--------------+
+ *        |DELETE_PARTITION_FINISHED |
+ *        +--------------------------+
+ * </PRE>
+ * </P>
+ */
+@InterfaceStability.Evolving
+public enum RemotePartitionDeleteState {
+
+    /**
+     * This is used when a topic/partition is marked for delete by the controller.
+     * That means, all its remote log segments are eligible for deletion so that remote partition removers can
+     * start deleting them.
+     */
+    DELETE_PARTITION_MARKED((byte) 0),
+
+    /**
+     * This state indicates that the partition deletion is started but not yet finished.
+     */
+    DELETE_PARTITION_STARTED((byte) 1),
+
+    /**
+     * This state indicates that the partition is deleted successfully.
+     */
+    DELETE_PARTITION_FINISHED((byte) 2);
+
+    private static final Map<Byte, RemotePartitionDeleteState> STATE_TYPES = Collections.unmodifiableMap(
+            Arrays.stream(values()).collect(Collectors.toMap(RemotePartitionDeleteState::id, Function.identity())));
+
+    private final byte id;
+
+    RemotePartitionDeleteState(byte id) {
+        this.id = id;
+    }
+
+    public byte id() {
+        return id;
+    }
+
+    public static RemotePartitionDeleteState forId(byte id) {
+        return STATE_TYPES.get(id);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteResourceNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteResourceNotFoundException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import static java.lang.String.format;
+
+/**
+ * Exception thrown when a resource is not found on the remote storage.
+ *
+ * A resource can be a log segment, any of the indexes or any which was stored in remote storage for a particular log
+ * segment.
+ */
+public class RemoteResourceNotFoundException extends RemoteStorageException {
+
+    public RemoteResourceNotFoundException(final RemoteLogSegmentId id, final String resourceName) {
+        super(format("Requested resource associated to the remote log segment was not found. " +
+                "ID: %s Resource name: %s", id.id(), resourceName));
+    }
+
+    public RemoteResourceNotFoundException(final String message) {
+        super(message);
+    }
+
+    public RemoteResourceNotFoundException(final Throwable cause) {
+        super("Requested remote resource was not found", cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteStorageException.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteStorageException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+/**
+ * Exception thrown when there is a remote storage error.
+ * This can be used as the base exception by implementors of
+ * {@link RemoteStorageManager} or {@link RemoteLogMetadataManager} to create extended exceptions.
+ */
+public class RemoteStorageException extends Exception {
+
+    public RemoteStorageException(final String message) {
+        super(message);
+    }
+
+    public RemoteStorageException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteStorageManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteStorageManager.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.storage;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.io.Closeable;
+import java.io.InputStream;
+
+/**
+ * This interface provides the lifecycle of remote log segments that includes copy, fetch, and delete from remote
+ * storage.
+ * <p>
+ * Each upload or copy of a segment is initiated with {@link RemoteLogSegmentMetadata} containing {@link RemoteLogSegmentId}
+ * which is universally unique even for the same topic partition and offsets.
+ * <p>
+ * {@link RemoteLogSegmentMetadata} is stored in {@link RemoteLogMetadataManager} before and after copy/delete operations on
+ * {@link RemoteStorageManager} with the respective {@link RemoteLogSegmentState}. {@link RemoteLogMetadataManager} is
+ * responsible for storing and fetching metadata about the remote log segments in a strongly consistent manner.
+ * This allows {@link RemoteStorageManager} to store segments even in eventually consistent manner as the metadata is already
+ * stored in a consistent store.
+ */
+@InterfaceStability.Evolving
+public interface RemoteStorageManager extends Configurable, Closeable {
+
+
+    /**
+     * Type of the index file.
+     */
+    enum IndexType {
+        /**
+         * Represents offset index.
+         */
+        Offset,
+
+        /**
+         * Represents timestamp index.
+         */
+        Timestamp,
+
+        /**
+         * Represents producer snapshot index.
+         */
+        ProducerSnapshot,
+
+        /**
+         * Represents transaction index.
+         */
+        Transaction,
+
+        /**
+         * Represents leader epoch index.
+         */
+        LeaderEpoch,
+    }
+
+    /**
+     * Copies the given {@link LogSegmentData} provided for the given {@param remoteLogSegmentMetadata}.
+     * <p>
+     * Invoker of this API should always send a unique id as part of {@link RemoteLogSegmentMetadata#remoteLogSegmentId()#id()}
+     * even when it retries to invoke this method for the same log segment data.
+     *
+     * @param remoteLogSegmentMetadata metadata about the remote log segment.
+     * @param logSegmentData           data to be copied to tiered storage.
+     * @throws RemoteStorageException if there are any errors in storing the data of the segment.
+     */
+    void copyLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata, LogSegmentData logSegmentData)
+            throws RemoteStorageException;
+
+    /**
+     * Returns the remote log segment data file/object as InputStream for the given {@link RemoteLogSegmentMetadata}
+     * starting from the given startPosition. The stream will end at the end of the remote log segment data file/object.
+     *
+     * @param remoteLogSegmentMetadata metadata about the remote log segment.
+     * @param startPosition            start position of log segment to be read, inclusive.
+     * @return input stream of the requested log segment data.
+     * @throws RemoteStorageException          if there are any errors while fetching the desired segment.
+     * @throws RemoteResourceNotFoundException when there are no resources associated with the given remoteLogSegmentMetadata.
+     */
+    InputStream fetchLogSegmentData(RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+                                    int startPosition) throws RemoteStorageException;
+
+    /**
+     * Returns the remote log segment data file/object as InputStream for the given {@link RemoteLogSegmentMetadata}
+     * starting from the given startPosition. The stream will end at the smaller of endPosition and the end of the
+     * remote log segment data file/object.
+     *
+     * @param remoteLogSegmentMetadata metadata about the remote log segment.
+     * @param startPosition            start position of log segment to be read, inclusive.
+     * @param endPosition              end position of log segment to be read, inclusive.
+     * @return input stream of the requested log segment data.
+     * @throws RemoteStorageException          if there are any errors while fetching the desired segment.
+     * @throws RemoteResourceNotFoundException when there are no resources associated with the given remoteLogSegmentMetadata.
+     */
+    InputStream fetchLogSegmentData(RemoteLogSegmentMetadata remoteLogSegmentMetadata,
+                                    int startPosition, int endPosition) throws RemoteStorageException;
+
+    /**
+     * Returns the index for the respective log segment of {@link RemoteLogSegmentMetadata}.
+     *
+     * @param remoteLogSegmentMetadata metadata about the remote log segment.
+     * @param indexType                type of the index to be fetched for the segment.
+     * @return input stream of the requested index.
+     * @throws RemoteStorageException          if there are any errors while fetching the index.
+     * @throws RemoteResourceNotFoundException when there are no resources associated with the given remoteLogSegmentMetadata.
+     */
+    InputStream fetchIndex(RemoteLogSegmentMetadata remoteLogSegmentMetadata, IndexType indexType) throws RemoteStorageException;
+
+    /**
+     * Deletes the resources associated with the given {@param remoteLogSegmentMetadata}. Deletion is considered as
+     * successful if this call returns successfully without any errors. It will throw {@link RemoteStorageException} if
+     * there are any errors in deleting the file.
+     * <p>
+     * {@param remoteLogSegmentMetadata}.
+     *
+     * @param remoteLogSegmentMetadata metadata about the remote log segment to be deleted.
+     * @throws RemoteResourceNotFoundException if the requested resource is not found
+     * @throws RemoteStorageException          if there are any storage related errors occurred.
+     * @throws RemoteResourceNotFoundException when there are no resources associated with the given remoteLogSegmentMetadata.
+     */
+    void deleteLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException;
+
+}


### PR DESCRIPTION
KAFKA-9548 Added RemoteStorageManager, RemoteLogMetadataManager and its related public classes.

KIP-405 introduced a few public APIs for plugging in implementations for remote log and metadata storages.
Key interfaces are
 -  RemoteStorageManager
 -  Remote LogMetadataManager

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
