### PR TITLE
MAJOR Added file based remote log metadata snapshots and other related changes. 

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -283,6 +283,12 @@
       <allow pkg="org.apache.kafka.server.common" />
       <allow pkg="org.apache.kafka.server.log" />
       <allow pkg="org.apache.kafka.test" />
+
+      <subpackage name="remote">
+        <allow pkg="scala.collection" />
+        <allow pkg="scala.jdk" />
+      </subpackage>
+
     </subpackage>
   </subpackage>
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedLogMetadataFile.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedLogMetadataFile.java
@@ -129,7 +129,7 @@ public class CommittedLogMetadataFile {
                 lenBuffer.rewind();
                 // Read the length of each entry
                 final int len = lenBuffer.getInt();
-                lenBuffer.flip();
+                lenBuffer.rewind();
 
                 // Read the entry
                 ByteBuffer data = ByteBuffer.allocate(len);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedLogMetadataFile.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedLogMetadataFile.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde;
+import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CommittedLogMetadataFile {
+
+    public static final String COMMITTED_LOG_METADATA_SNAPSHOT_FILE_NAME = "remote_log_snapshot";
+
+    // header: <version:short><topicId:2 longs><metadata-partition:int><metadata-partition-offset:long>
+    // size: 2 + (8+8) + 4 + 8 = 30
+    private static final int HEADER_SIZE = 30;
+
+    private final File metadataStoreFile;
+
+    CommittedLogMetadataFile(TopicIdPartition topicIdPartition,
+                             Path metadataStoreDir) {
+        this.metadataStoreFile = new File(metadataStoreDir.toFile(), COMMITTED_LOG_METADATA_SNAPSHOT_FILE_NAME);
+
+        if (!metadataStoreFile.exists()) {
+            try {
+                metadataStoreFile.createNewFile();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public synchronized void write(Snapshot snapshot) throws IOException {
+        File newMetadataStoreFile = new File(metadataStoreFile.getAbsolutePath() + ".new");
+        try (FileOutputStream fileOutputStream = new FileOutputStream(newMetadataStoreFile);
+             BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream)) {
+
+            ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_SIZE);
+
+            // Write version
+            headerBuffer.putShort(snapshot.version);
+            bufferedOutputStream.write(headerBuffer.array());
+
+            // Write topic-id
+            headerBuffer.putLong(snapshot.topicId.getMostSignificantBits());
+            headerBuffer.putLong(snapshot.topicId.getLeastSignificantBits());
+
+            // Write metadata partition and metadata partition offset
+            headerBuffer.putInt(snapshot.metadataPartition);
+            headerBuffer.putLong(snapshot.metadataPartitionOffset);
+
+            // Write header
+            bufferedOutputStream.write(headerBuffer.array());
+
+            // Write each entry
+            ByteBuffer lenBuffer = ByteBuffer.allocate(8);
+            RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
+            for (RemoteLogSegmentMetadata remoteLogSegmentMetadata : snapshot.remoteLogMetadatas) {
+                final byte[] serializedBytes = serde.serialize(remoteLogSegmentMetadata);
+                // Write length
+                lenBuffer.putInt(serializedBytes.length);
+                bufferedOutputStream.write(lenBuffer.array());
+                lenBuffer.flip();
+
+                // Write data
+                bufferedOutputStream.write(serializedBytes);
+            }
+
+            fileOutputStream.getFD().sync();
+        }
+
+        Utils.atomicMoveWithFallback(newMetadataStoreFile.toPath(), metadataStoreFile.toPath());
+    }
+
+    @SuppressWarnings("unchecked")
+    public synchronized Snapshot read() throws IOException {
+
+        // Checking for empty files.
+        if (metadataStoreFile.length() == 0) {
+            throw new IOException("Empty snapshot file.");
+        }
+
+        try (FileInputStream fis = new FileInputStream(metadataStoreFile)) {
+
+            // Read header
+            ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_SIZE);
+            fis.read(headerBuffer.array());
+
+            Short version = headerBuffer.getShort();
+            Uuid topicId = new Uuid(headerBuffer.getLong(), headerBuffer.getLong());
+            int metadataPartition = headerBuffer.getInt();
+            long metadataPartitionOffset = headerBuffer.getLong();
+
+            RemoteLogMetadataSerde serde = new RemoteLogMetadataSerde();
+
+            List<RemoteLogSegmentMetadata> result = new ArrayList<>();
+
+            ByteBuffer lenBuffer = ByteBuffer.allocate(4);
+            while (fis.read(lenBuffer.array()) != -1) {
+                // Read the length of each entry
+                final int len = lenBuffer.getInt();
+                lenBuffer.flip();
+
+                // Read the entry
+                byte[] data = new byte[len];
+                final int read = fis.read(data);
+                if (read != len) {
+                    throw new IOException("Invalid amount of data read, file may have been corrupted.");
+                }
+
+                // We are always adding RemoteLogSegmentMetadata only as you can see in #write() method.
+                // Did not add a specific serde for RemoteLogSegmentMetadata and reusing RemoteLogMetadataSerde
+                final RemoteLogSegmentMetadata remoteLogSegmentMetadata = (RemoteLogSegmentMetadata) serde.deserialize(data);
+                result.add(remoteLogSegmentMetadata);
+            }
+
+            return new Snapshot(version, topicId, metadataPartition, metadataPartitionOffset, result);
+        }
+    }
+
+    public static final class Snapshot {
+        private static final short CURRENT_VERSION = 0;
+
+        private final short version;
+        private final Uuid topicId;
+        private final int metadataPartition;
+        private final long metadataPartitionOffset;
+        private final Collection<RemoteLogSegmentMetadata> remoteLogMetadatas;
+
+        public Snapshot(Uuid topicId,
+                        int metadataPartition,
+                        long metadataPartitionOffset,
+                        Collection<RemoteLogSegmentMetadata> remoteLogMetadatas) {
+            this(CURRENT_VERSION, topicId, metadataPartition, metadataPartitionOffset, remoteLogMetadatas);
+        }
+
+        public Snapshot(short version,
+                        Uuid topicId,
+                        int metadataPartition,
+                        long metadataPartitionOffset,
+                        Collection<RemoteLogSegmentMetadata> remoteLogMetadatas) {
+            this.version = version;
+            this.topicId = topicId;
+            this.metadataPartition = metadataPartition;
+            this.metadataPartitionOffset = metadataPartitionOffset;
+            this.remoteLogMetadatas = remoteLogMetadatas;
+        }
+
+        public short version() {
+            return version;
+        }
+
+        public Uuid topicId() {
+            return topicId;
+        }
+
+        public int metadataPartition() {
+            return metadataPartition;
+        }
+
+        public long metadataPartitionOffset() {
+            return metadataPartitionOffset;
+        }
+
+        public Collection<RemoteLogSegmentMetadata> remoteLogMetadatas() {
+            return remoteLogMetadatas;
+        }
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedOffsetsFile.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedOffsetsFile.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.server.log.remote.metadata.storage;
+
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+class CommittedOffsetsFile {
+    private static final String SEPARATOR = " ";
+    private final File offsetsFile;
+
+    private static final Pattern MINIMUM_ONE_WHITESPACE = Pattern.compile("\\s+");
+
+    CommittedOffsetsFile(File offsetsFile) {
+        this.offsetsFile = offsetsFile;
+    }
+
+    public synchronized void write(Map<Integer, Long> committedOffsets) throws IOException {
+        File newOffsetsFile = new File(offsetsFile.getAbsolutePath() + ".new");
+
+        // Overwrite the file if it exists.
+        FileOutputStream fos = new FileOutputStream(newOffsetsFile);
+        try (final BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(fos, StandardCharsets.UTF_8))) {
+            for (Map.Entry<Integer, Long> entry : committedOffsets.entrySet()) {
+                writer.write(entry.getKey() + SEPARATOR + entry.getValue());
+                writer.newLine();
+            }
+
+            writer.flush();
+            fos.getFD().sync();
+        }
+
+        Utils.atomicMoveWithFallback(newOffsetsFile.toPath(), offsetsFile.toPath());
+    }
+
+    public synchronized Map<Integer, Long> read() throws IOException {
+        Map<Integer, Long> partitionToOffsets = new HashMap<>();
+
+        try (BufferedReader bufferedReader = Files.newBufferedReader(offsetsFile.toPath(), StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                String[] strings = MINIMUM_ONE_WHITESPACE.split(line);
+                if (strings.length != 2) {
+                    throw new IOException("Invalid format in line: " + line);
+                }
+                int partition = Integer.parseInt(strings[0]);
+                long offset = Long.parseLong(strings[1]);
+                partitionToOffsets.put(partition, offset);
+            }
+        }
+
+        return partitionToOffsets;
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
@@ -27,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -36,24 +38,24 @@ public class ConsumerManager implements Closeable {
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerManager.class);
     private static final long CONSUME_RECHECK_INTERVAL_MS = 50L;
+    private static final String COMMITTED_OFFSETS_FILE_NAME = "_rlmm_committed_offsets";
 
     private final TopicBasedRemoteLogMetadataManagerConfig rlmmConfig;
-    private final RemoteLogMetadataTopicPartitioner topicPartitioner;
     private final Time time;
     private final ConsumerTask consumerTask;
     private final Thread consumerTaskThread;
 
     public ConsumerManager(TopicBasedRemoteLogMetadataManagerConfig rlmmConfig,
                            RemotePartitionMetadataEventHandler remotePartitionMetadataEventHandler,
-                           RemoteLogMetadataTopicPartitioner rlmmTopicPartitioner,
+                           RemoteLogMetadataTopicPartitioner topicPartitioner,
                            Time time) {
         this.rlmmConfig = rlmmConfig;
-        this.topicPartitioner = rlmmTopicPartitioner;
         this.time = time;
 
         //Create a task to consume messages and submit the respective events to RemotePartitionMetadataEventHandler.
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(rlmmConfig.consumerProperties());
-        consumerTask = new ConsumerTask(consumer, remotePartitionMetadataEventHandler, topicPartitioner);
+        Path committedOffsetsPath = new File(rlmmConfig.logDir(), COMMITTED_OFFSETS_FILE_NAME).toPath();
+        consumerTask = new ConsumerTask(consumer, remotePartitionMetadataEventHandler, topicPartitioner, committedOffsetsPath, time, 60_000L);
         consumerTaskThread = KafkaThread.daemon("RLMMConsumerTask", consumerTask);
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerManager.java
@@ -63,6 +63,7 @@ public class ConsumerManager implements Closeable {
         try {
             // Start a thread to continuously consume records from topic partitions.
             consumerTaskThread.start();
+            log.info("RLMM Consumer task thread is started");
         } catch (Exception e) {
             throw new KafkaException("Error encountered while initializing and scheduling ConsumerTask thread", e);
         }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/ConsumerTask.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.log.remote.metadata.storage.serialization.RemoteLogMetadataSerde;
 import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
@@ -29,8 +30,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -66,6 +71,7 @@ class ConsumerTask implements Runnable, Closeable {
     private final KafkaConsumer<byte[], byte[]> consumer;
     private final RemotePartitionMetadataEventHandler remotePartitionMetadataEventHandler;
     private final RemoteLogMetadataTopicPartitioner topicPartitioner;
+    private final Time time;
 
     private volatile boolean close = false;
     private volatile boolean assignPartitions = false;
@@ -80,18 +86,64 @@ class ConsumerTask implements Runnable, Closeable {
 
     // Map of remote log metadata topic partition to consumed offsets.
     private final Map<Integer, Long> partitionToConsumedOffsets = new ConcurrentHashMap<>();
+    private Map<Integer, Long> committedPartitionToConsumedOffsets = Collections.emptyMap();
+
+    private final long committedOffsetSyncIntervalMs;
+    private CommittedOffsetsFile committedOffsetsFile;
+    private long lastSyncedTimeMs;
 
     public ConsumerTask(KafkaConsumer<byte[], byte[]> consumer,
                         RemotePartitionMetadataEventHandler remotePartitionMetadataEventHandler,
-                        RemoteLogMetadataTopicPartitioner topicPartitioner) {
+                        RemoteLogMetadataTopicPartitioner topicPartitioner,
+                        Path committedOffsetsPath,
+                        Time time,
+                        long committedOffsetSyncIntervalMs) {
         this.consumer = consumer;
         this.remotePartitionMetadataEventHandler = remotePartitionMetadataEventHandler;
         this.topicPartitioner = topicPartitioner;
+        this.time = time;
+        this.committedOffsetSyncIntervalMs = committedOffsetSyncIntervalMs;
+        initializeConsumerAssignment(committedOffsetsPath);
+    }
+
+    private void initializeConsumerAssignment(Path committedOffsetsPath) {
+        // look whether the committed file exists or not.
+        File file = committedOffsetsPath.toFile();
+        committedOffsetsFile = new CommittedOffsetsFile(file);
+        try {
+            if (file.createNewFile()) {
+                log.info("Created file: [{}] successfully", file);
+            } else {
+                // load committed offset and assign them in the consumer
+                final Map<Integer, Long> committedOffsets = committedOffsetsFile.read();
+                final Set<Map.Entry<Integer, Long>> entries = committedOffsets.entrySet();
+
+                if (!entries.isEmpty()) {
+                    // assign topic partitions from the earlier committed offsets file.
+                    Set<Integer> earlierAssignedPartitions = committedOffsets.keySet();
+                    assignedMetaPartitions.addAll(earlierAssignedPartitions);
+                    Set<TopicPartition> metadataTopicPartitions = earlierAssignedPartitions.stream()
+                                                                                        .map(x -> new TopicPartition(REMOTE_LOG_METADATA_TOPIC_NAME, x))
+                                                                                        .collect(Collectors.toSet());
+                    consumer.assign(metadataTopicPartitions);
+
+                    // Seek to the committed offsets
+                    for (Map.Entry<Integer, Long> entry : entries) {
+                        partitionToConsumedOffsets.put(entry.getKey(), entry.getValue());
+                        consumer.seek(new TopicPartition(REMOTE_LOG_METADATA_TOPIC_NAME, entry.getKey()), entry.getValue());
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // Ignore the error and consumer consumes from the earliest offset.
+            log.error("Encountered error while building committed offsets from the file", e);
+        }
     }
 
     @Override
     public void run() {
         log.info("Started Consumer task thread.");
+        lastSyncedTimeMs = time.milliseconds();
         try {
             while (!close) {
                 Set<Integer> assignedMetaPartitionsSnapshot = maybeWaitForPartitionsAssignment();
@@ -107,13 +159,38 @@ class ConsumerTask implements Runnable, Closeable {
                     handleRemoteLogMetadata(serde.deserialize(record.value()));
                     partitionToConsumedOffsets.put(record.partition(), record.offset());
                 }
+
+                syncCommittedDataAndOffsets(false);
             }
         } catch (Exception e) {
             log.error("Error occurred in consumer task, close:[{}]", close, e);
+        } finally {
+            closeConsumer();
         }
 
-        closeConsumer();
         log.info("Exiting from consumer task thread");
+    }
+
+    private void syncCommittedDataAndOffsets(boolean forceSync) {
+        boolean noOffsetUpdates = committedPartitionToConsumedOffsets.equals(partitionToConsumedOffsets);
+        if (noOffsetUpdates || !forceSync && time.milliseconds() - lastSyncedTimeMs < committedOffsetSyncIntervalMs) {
+            log.debug("Skip syncing committed offsets, noOffsetUpdates: {}, forceSync: {}", noOffsetUpdates, forceSync);
+            return;
+        }
+
+        try {
+            // todo sync the snapshot file
+            for (TopicIdPartition topicIdPartition : assignedTopicPartitions) {
+                int metadataPartition = topicPartitioner.metadataPartition(topicIdPartition);
+                remotePartitionMetadataEventHandler.syncLogMetadataDataFile(topicIdPartition, metadataPartition, partitionToConsumedOffsets.get(metadataPartition));
+            }
+
+            committedOffsetsFile.write(partitionToConsumedOffsets);
+            committedPartitionToConsumedOffsets = new HashMap<>(partitionToConsumedOffsets);
+            lastSyncedTimeMs = time.milliseconds();
+        } catch (IOException e) {
+            log.error("Error encountered while writing committed offsets to a local file", e);
+        }
     }
 
     private void closeConsumer() {
@@ -224,6 +301,7 @@ class ConsumerTask implements Runnable, Closeable {
         if (!close) {
             close = true;
             consumer.wakeup();
+            syncCommittedDataAndOffsets(true);
         }
     }
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/FileBasedRemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/FileBasedRemoteLogMetadataCache.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.metadata.storage;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicIdPartition;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class FileBasedRemoteLogMetadataCache extends RemoteLogMetadataCache {
+
+    private final CommittedLogMetadataFile committedLogMetadataFile;
+    private final TopicIdPartition topicIdPartition;
+
+    public FileBasedRemoteLogMetadataCache(TopicIdPartition topicIdPartition,
+                                           Path partitionDir) {
+        if(!partitionDir.toFile().exists() || !partitionDir.toFile().isDirectory()) {
+            throw new KafkaException("Given partition directory:" + partitionDir + " must be an existing directory.");
+        }
+
+        this.topicIdPartition = topicIdPartition;
+        committedLogMetadataFile = new CommittedLogMetadataFile(topicIdPartition, partitionDir);
+    }
+
+    public void flushToFile(int metadataPartition,
+                            Long metadataPartitionOffset) throws IOException {
+        // todo-tier take a lock here as the metadata may be getting modified.
+        // For each topic partition, there is only one thread updating the cache. But in future, if we want to parallelize then we may need to take
+        // a lock.
+        committedLogMetadataFile.write(new CommittedLogMetadataFile.Snapshot(topicIdPartition.topicId(), metadataPartition, metadataPartitionOffset,
+                                                                             idToSegmentMetadata.values()));
+    }
+}

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/FileBasedRemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/FileBasedRemoteLogMetadataCache.java
@@ -29,12 +29,19 @@ public class FileBasedRemoteLogMetadataCache extends RemoteLogMetadataCache {
 
     public FileBasedRemoteLogMetadataCache(TopicIdPartition topicIdPartition,
                                            Path partitionDir) {
-        if(!partitionDir.toFile().exists() || !partitionDir.toFile().isDirectory()) {
+        if (!partitionDir.toFile().exists() || !partitionDir.toFile().isDirectory()) {
             throw new KafkaException("Given partition directory:" + partitionDir + " must be an existing directory.");
         }
 
         this.topicIdPartition = topicIdPartition;
         committedLogMetadataFile = new CommittedLogMetadataFile(topicIdPartition, partitionDir);
+
+        try {
+            committedLogMetadataFile.read().ifPresent(snapshot -> loadRemoteLogSegmentMetadata(snapshot.remoteLogMetadatas()));
+        } catch (IOException e) {
+            throw new KafkaException(e);
+        }
+
     }
 
     public void flushToFile(int metadataPartition,

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
@@ -95,7 +95,7 @@ public class RemoteLogMetadataCache {
     private static final Logger log = LoggerFactory.getLogger(RemoteLogMetadataCache.class);
 
     // It contains all the segment-id to metadata mappings which did not reach the terminal state viz DELETE_SEGMENT_FINISHED.
-    private final ConcurrentMap<RemoteLogSegmentId, RemoteLogSegmentMetadata> idToSegmentMetadata
+    protected final ConcurrentMap<RemoteLogSegmentId, RemoteLogSegmentMetadata> idToSegmentMetadata
             = new ConcurrentHashMap<>();
 
     // It contains leader epoch to the respective entry containing the state.

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataCache.java
@@ -24,6 +24,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundExceptio
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -161,53 +162,46 @@ public class RemoteLogMetadataCache {
                 throw new IllegalArgumentException("metadataUpdate: " + metadataUpdate + " with state " + RemoteLogSegmentState.COPY_SEGMENT_STARTED +
                                                    " can not be updated");
             case COPY_SEGMENT_FINISHED:
-                handleSegmentWithCopySegmentFinishedState(metadataUpdate, existingMetadata);
+                handleSegmentWithCopySegmentFinishedState(existingMetadata.createWithUpdates(metadataUpdate));
                 break;
             case DELETE_SEGMENT_STARTED:
-                handleSegmentWithDeleteSegmentStartedState(metadataUpdate, existingMetadata);
+                handleSegmentWithDeleteSegmentStartedState(existingMetadata.createWithUpdates(metadataUpdate));
                 break;
             case DELETE_SEGMENT_FINISHED:
-                handleSegmentWithDeleteSegmentFinishedState(metadataUpdate, existingMetadata);
+                handleSegmentWithDeleteSegmentFinishedState(existingMetadata.createWithUpdates(metadataUpdate));
                 break;
             default:
                 throw new IllegalArgumentException("Metadata with the state " + targetState + " is not supported");
         }
     }
 
-    private void handleSegmentWithCopySegmentFinishedState(RemoteLogSegmentMetadataUpdate metadataUpdate,
-                                                           RemoteLogSegmentMetadata existingMetadata) {
-        log.debug("Adding remote log segment metadata to leader epoch mappings with update: [{}]", metadataUpdate);
-
-        doHandleSegmentStateTransitionForLeaderEpochs(existingMetadata,
+    private void handleSegmentWithCopySegmentFinishedState(RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
+        doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
                 RemoteLogLeaderEpochState::handleSegmentWithCopySegmentFinishedState);
 
         // Put the entry with the updated metadata.
-        idToSegmentMetadata.put(existingMetadata.remoteLogSegmentId(),
-                existingMetadata.createWithUpdates(metadataUpdate));
+        idToSegmentMetadata.put(remoteLogSegmentMetadata.remoteLogSegmentId(), remoteLogSegmentMetadata);
     }
 
-    private void handleSegmentWithDeleteSegmentStartedState(RemoteLogSegmentMetadataUpdate metadataUpdate,
-                                                            RemoteLogSegmentMetadata existingMetadata) {
-        log.debug("Cleaning up the state for : [{}]", metadataUpdate);
+    private void handleSegmentWithDeleteSegmentStartedState(RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
+        log.debug("Cleaning up the state for : [{}]", remoteLogSegmentMetadata);
 
-        doHandleSegmentStateTransitionForLeaderEpochs(existingMetadata,
+        doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
                 RemoteLogLeaderEpochState::handleSegmentWithDeleteSegmentStartedState);
 
         // Put the entry with the updated metadata.
-        idToSegmentMetadata.put(existingMetadata.remoteLogSegmentId(),
-                existingMetadata.createWithUpdates(metadataUpdate));
+        idToSegmentMetadata.put(remoteLogSegmentMetadata.remoteLogSegmentId(), remoteLogSegmentMetadata);
     }
 
-    private void handleSegmentWithDeleteSegmentFinishedState(RemoteLogSegmentMetadataUpdate metadataUpdate,
-                                                             RemoteLogSegmentMetadata existingMetadata) {
-        log.debug("Removing the entry as it reached the terminal state: [{}]", metadataUpdate);
+    private void handleSegmentWithDeleteSegmentFinishedState(RemoteLogSegmentMetadata remoteLogSegmentMetadata) {
+        log.debug("Removing the entry as it reached the terminal state: [{}]", remoteLogSegmentMetadata);
 
-        doHandleSegmentStateTransitionForLeaderEpochs(existingMetadata,
+        doHandleSegmentStateTransitionForLeaderEpochs(remoteLogSegmentMetadata,
                 RemoteLogLeaderEpochState::handleSegmentWithDeleteSegmentFinishedState);
 
         // Remove the segment's id to metadata mapping because this segment is considered as deleted and it cleared all
         // the state of this segment in the cache.
-        idToSegmentMetadata.remove(existingMetadata.remoteLogSegmentId());
+        idToSegmentMetadata.remove(remoteLogSegmentMetadata.remoteLogSegmentId());
     }
 
     private void doHandleSegmentStateTransitionForLeaderEpochs(RemoteLogSegmentMetadata existingMetadata,
@@ -310,6 +304,25 @@ public class RemoteLogMetadataCache {
         if (!RemoteLogSegmentState.isValidTransition(existingState, targetState)) {
             throw new IllegalStateException(
                     "Current state: " + existingState + " can not be transitioned to target state: " + targetState);
+        }
+    }
+
+    protected void loadRemoteLogSegmentMetadata(Collection<RemoteLogSegmentMetadata> remoteLogSegmentMetadatas) {
+        for (RemoteLogSegmentMetadata remoteLogSegmentMetadata : remoteLogSegmentMetadatas) {
+            switch (remoteLogSegmentMetadata.state()) {
+                case COPY_SEGMENT_STARTED:
+                    addCopyInProgressSegment(remoteLogSegmentMetadata);
+                    break;
+                case COPY_SEGMENT_FINISHED:
+                    handleSegmentWithCopySegmentFinishedState(remoteLogSegmentMetadata);
+                    break;
+                case DELETE_SEGMENT_STARTED:
+                    handleSegmentWithDeleteSegmentStartedState(remoteLogSegmentMetadata);
+                    break;
+                case DELETE_SEGMENT_FINISHED:
+                default:
+                    throw new IllegalArgumentException("Given remoteLogSegmentMetadata has invalid state: " + remoteLogSegmentMetadata);
+            }
         }
     }
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataEventHandler.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataEventHandler.java
@@ -16,10 +16,13 @@
  */
 package org.apache.kafka.server.log.remote.metadata.storage;
 
+import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.server.log.remote.storage.RemoteLogMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadataUpdate;
 import org.apache.kafka.server.log.remote.storage.RemotePartitionDeleteMetadata;
+
+import java.io.IOException;
 
 public abstract class RemotePartitionMetadataEventHandler {
 
@@ -40,4 +43,9 @@ public abstract class RemotePartitionMetadataEventHandler {
     protected abstract void handleRemoteLogSegmentMetadataUpdate(RemoteLogSegmentMetadataUpdate remoteLogSegmentMetadataUpdate);
 
     protected abstract void handleRemotePartitionDeleteMetadata(RemotePartitionDeleteMetadata remotePartitionDeleteMetadata);
+
+    public abstract void syncLogMetadataDataFile(TopicIdPartition topicIdPartition,
+                                                 int metadataPartition,
+                                                 Long metadataPartitionOffset) throws IOException;
+
 }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -33,6 +33,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -71,7 +72,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
     // requests calling different methods which use the resources like producer/consumer managers.
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-    private final RemotePartitionMetadataStore remotePartitionMetadataStore = new RemotePartitionMetadataStore();
+    private RemotePartitionMetadataStore remotePartitionMetadataStore;
     private volatile TopicBasedRemoteLogMetadataManagerConfig rlmmConfig;
     private RemoteLogMetadataTopicPartitioner rlmmTopicPartitioner;
 
@@ -261,6 +262,7 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
 
             rlmmConfig = new TopicBasedRemoteLogMetadataManagerConfig(configs);
             rlmmTopicPartitioner = new RemoteLogMetadataTopicPartitioner(rlmmConfig.metadataTopicPartitionsCount());
+            remotePartitionMetadataStore = new RemotePartitionMetadataStore(new File(rlmmConfig.logDir()).toPath());
             configured = true;
             log.info("Successfully initialized with rlmmConfig: {}", rlmmConfig);
 

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManager.java
@@ -231,6 +231,9 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
 
             HashSet<TopicIdPartition> allPartitions = new HashSet<>(leaderPartitions);
             allPartitions.addAll(followerPartitions);
+            for (TopicIdPartition partition : allPartitions) {
+                remotePartitionMetadataStore.maybeLoadPartition(partition);
+            }
             consumerManager.addAssignmentsForPartitions(allPartitions);
         } finally {
             lock.readLock().unlock();
@@ -311,6 +314,11 @@ public class TopicBasedRemoteLogMetadataManager implements RemoteLogMetadataMana
             throw new IllegalStateException("This instance is in invalid state, initialized: " + initialized +
                                             " close: " + close);
         }
+    }
+
+    // Visible for testing.
+    public TopicBasedRemoteLogMetadataManagerConfig config() {
+        return rlmmConfig;
     }
 
     @Override

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -63,9 +63,10 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     public static final String REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX = "remote.log.metadata.common.client.";
     public static final String REMOTE_LOG_METADATA_PRODUCER_PREFIX = "remote.log.metadata.producer.";
     public static final String REMOTE_LOG_METADATA_CONSUMER_PREFIX = "remote.log.metadata.consumer.";
+    public static final String BROKER_ID = "broker.id";
+    public static final String LOG_DIR = "log.dir";
 
     private static final String REMOTE_LOG_METADATA_CLIENT_PREFIX = "__remote_log_metadata_client";
-    private static final String BROKER_ID = "broker.id";
 
     private static final ConfigDef CONFIG = new ConfigDef();
     static {
@@ -82,6 +83,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     private final String clientIdPrefix;
     private final int metadataTopicPartitionsCount;
     private final String bootstrapServers;
+    private final String logDir;
     private final long consumeWaitMs;
     private final long metadataTopicRetentionMillis;
 
@@ -97,6 +99,12 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
         bootstrapServers = (String) props.get(BOOTSTRAP_SERVERS_CONFIG);
         if (bootstrapServers == null || bootstrapServers.isEmpty()) {
             throw new IllegalArgumentException(BOOTSTRAP_SERVERS_CONFIG + " config must not be null or empty.");
+        }
+
+
+        logDir = (String) props.get(LOG_DIR);
+        if (logDir == null || logDir.isEmpty()) {
+            throw new IllegalArgumentException(LOG_DIR + " config must not be null or empty.");
         }
 
         consumeWaitMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP);
@@ -148,6 +156,10 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
     public long consumeWaitMs() {
         return consumeWaitMs;
+    }
+
+    public String logDir() {
+        return logDir;
     }
 
     public Map<String, Object> consumerProperties() {

--- a/storage/src/main/resources/message/RemoteLogSegmentMetadataRecordSnapshot.json
+++ b/storage/src/main/resources/message/RemoteLogSegmentMetadataRecordSnapshot.json
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 0,
+  "type": "data",
+  "name": "RemoteLogSegmentMetadataRecordSnapshot",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    {
+      "name": "SegmentId",
+      "type": "uuid",
+      "versions": "0+",
+      "about": "Unique identifier of the log segment"
+    },
+    {
+      "name": "StartOffset",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Start offset  of the segment."
+    },
+    {
+      "name": "EndOffset",
+      "type": "int64",
+      "versions": "0+",
+      "about": "End offset  of the segment."
+    },
+    {
+      "name": "BrokerId",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Broker (controller or leader) id from which this event is created. DELETE_PARTITION_MARKED is sent by the controller. DELETE_PARTITION_STARTED and DELETE_PARTITION_FINISHED are sent by remote log metadata topic partition leader."
+    },
+    {
+      "name": "MaxTimestamp",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Maximum timestamp with in this segment."
+    },
+    {
+      "name": "EventTimestamp",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Event timestamp of this segment."
+    },
+    {
+      "name": "SegmentLeaderEpochs",
+      "type": "[]SegmentLeaderEpochEntry",
+      "versions": "0+",
+      "about": "Event timestamp of this segment.",
+      "fields": [
+        {
+          "name": "LeaderEpoch",
+          "type": "int32",
+          "versions": "0+",
+          "about": "Leader epoch"
+        },
+        {
+          "name": "Offset",
+          "type": "int64",
+          "versions": "0+",
+          "about": "Start offset for the leader epoch"
+        }
+      ]
+    },
+    {
+      "name": "SegmentSizeInBytes",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Segment size in bytes"
+    },
+    {
+      "name": "RemoteLogSegmentState",
+      "type": "int8",
+      "versions": "0+",
+      "about": "State of the remote log segment"
+    }
+  ]
+}

--- a/storage/src/main/resources/message/RemotePartitionDleteMetadataSnapshot.json
+++ b/storage/src/main/resources/message/RemotePartitionDleteMetadataSnapshot.json
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 1,
+  "type": "data",
+  "name": "RemotePartitionDeleteMetadataSnapshot",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    {
+      "name": "BrokerId",
+      "type": "int32",
+      "versions": "0+",
+      "about": "Broker (controller or leader) id from which this event is created. DELETE_PARTITION_MARKED is sent by the controller. DELETE_PARTITION_STARTED and DELETE_PARTITION_FINISHED are sent by remote log metadata topic partition leader."
+    },
+    {
+      "name": "EventTimestamp",
+      "type": "int64",
+      "versions": "0+",
+      "about": "Event timestamp of this segment."
+    },
+    {
+      "name": "RemotePartitionDeleteState",
+      "type": "int8",
+      "versions": "0+",
+      "about": "Deletion state of the remote partition"
+    }
+  ]
+}

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedLogMetadataFileTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/CommittedLogMetadataFileTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+public class CommittedLogMetadataFileTest {
+
+    @Test
+    public void testWriteReadCommittedLogMetadataFile() throws Exception {
+        TopicIdPartition topicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("foo", 0));
+        File metadataStoreDir = TestUtils.tempDirectory("_rlmm_committed");
+        CommittedLogMetadataFile committedLogMetadataFile = new CommittedLogMetadataFile(topicIdPartition, metadataStoreDir.toPath());
+
+        List<RemoteLogSegmentMetadata> remoteLogSegmentMetadatas = new ArrayList<>();
+        long startOffset = 0;
+        for (int i = 0; i < 100; i++) {
+            long endOffset = startOffset + 100L;
+            remoteLogSegmentMetadatas.add(
+                    new RemoteLogSegmentMetadata(new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid()), startOffset, endOffset,
+                                                 System.currentTimeMillis(), 1, 100, 1024, Collections.singletonMap(i, startOffset)));
+            startOffset = endOffset + 1;
+        }
+
+        CommittedLogMetadataFile.Snapshot snapshot = new CommittedLogMetadataFile.Snapshot(topicIdPartition.topicId(), 0, 120,
+                                                                                           remoteLogSegmentMetadatas);
+        committedLogMetadataFile.write(snapshot);
+
+        Optional<CommittedLogMetadataFile.Snapshot> maybeReadSnapshot = committedLogMetadataFile.read();
+        Assertions.assertTrue(maybeReadSnapshot.isPresent());
+
+        Assertions.assertEquals(snapshot, maybeReadSnapshot.get());
+        Assertions.assertEquals(new HashSet<>(snapshot.remoteLogMetadatas()), new HashSet<>(maybeReadSnapshot.get().remoteLogMetadatas()));
+    }
+}

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -428,38 +428,38 @@ public class RemoteLogSegmentLifecycleTest {
         @Override
         public synchronized void initialize(TopicIdPartition topicIdPartition) {
             this.topicIdPartition = topicIdPartition;
-            super.initialize(Collections.singleton(topicIdPartition));
+            super.initialize(Collections.singleton(topicIdPartition), true);
         }
 
         @Override
         public void addRemoteLogSegmentMetadata(RemoteLogSegmentMetadata segmentMetadata) throws RemoteStorageException {
-            topicBasedRlmm().addRemoteLogSegmentMetadata(segmentMetadata);
+            remoteLogMetadataManager().addRemoteLogSegmentMetadata(segmentMetadata);
         }
 
         @Override
         public void updateRemoteLogSegmentMetadata(RemoteLogSegmentMetadataUpdate segmentMetadataUpdate) throws RemoteStorageException {
-            topicBasedRlmm().updateRemoteLogSegmentMetadata(segmentMetadataUpdate);
+            remoteLogMetadataManager().updateRemoteLogSegmentMetadata(segmentMetadataUpdate);
         }
 
         @Override
         public Optional<Long> highestOffsetForEpoch(int leaderEpoch) throws RemoteStorageException {
-            return topicBasedRlmm().highestOffsetForEpoch(topicIdPartition, leaderEpoch);
+            return remoteLogMetadataManager().highestOffsetForEpoch(topicIdPartition, leaderEpoch);
         }
 
         @Override
         public Optional<RemoteLogSegmentMetadata> remoteLogSegmentMetadata(int leaderEpoch,
                                                                            long offset) throws RemoteStorageException {
-            return topicBasedRlmm().remoteLogSegmentMetadata(topicIdPartition, leaderEpoch, offset);
+            return remoteLogMetadataManager().remoteLogSegmentMetadata(topicIdPartition, leaderEpoch, offset);
         }
 
         @Override
         public Iterator<RemoteLogSegmentMetadata> listRemoteLogSegments(int leaderEpoch) throws RemoteStorageException {
-            return topicBasedRlmm().listRemoteLogSegments(topicIdPartition, leaderEpoch);
+            return remoteLogMetadataManager().listRemoteLogSegments(topicIdPartition, leaderEpoch);
         }
 
         @Override
         public Iterator<RemoteLogSegmentMetadata> listAllRemoteLogSegments() throws RemoteStorageException {
-            return topicBasedRlmm().listRemoteLogSegments(topicIdPartition);
+            return remoteLogMetadataManager().listRemoteLogSegments(topicIdPartition);
         }
 
         @Override

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundExceptio
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.server.log.remote.storage.RemoteResourceNotFoundExceptio
 import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfigTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfigTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.server.log.remote.metadata.storage;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -29,6 +30,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.BROKER_ID;
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.LOG_DIR;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_COMMON_CLIENT_PREFIX;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_CONSUMER_PREFIX;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_PRODUCER_PREFIX;
@@ -123,7 +126,8 @@ public class TopicBasedRemoteLogMetadataManagerConfigTest {
                                                        Map<String, Object> consumerConfig) {
         Map<String, Object> props = new HashMap<>();
         props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
-        props.put("broker.id", 1);
+        props.put(BROKER_ID, 1);
+        props.put(LOG_DIR, TestUtils.tempDirectory().getAbsolutePath());
 
         props.put(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP, 3);
         props.put(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, 10);

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.server.log.remote.metadata.storage;
 
 import kafka.api.IntegrationTestHarness;
-import kafka.utils.TestUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.config.TopicConfig;
@@ -35,6 +34,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.BROKER_ID;
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.LOG_DIR;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP;
 import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS_PROP;
@@ -65,7 +66,8 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
         // Initialize TopicBasedRemoteLogMetadataManager.
         Map<String, Object> configs = new HashMap<>();
         configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerList());
-        configs.put("broker.id", 0);
+        configs.put(BROKER_ID, 0);
+        configs.put(LOG_DIR, org.apache.kafka.test.TestUtils.tempDirectory("rlmm_segs_").getAbsolutePath());
         configs.put(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, METADATA_TOPIC_PARTITIONS_COUNT);
         configs.put(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP, METADATA_TOPIC_REPLICATION_FACTOR);
         configs.put(REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS_PROP, METADATA_TOPIC_RETENTION_MS);
@@ -110,7 +112,7 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
     private void createMetadataTopic() {
         Properties topicConfigs = new Properties();
         topicConfigs.put(TopicConfig.RETENTION_MS_CONFIG, Long.toString(METADATA_TOPIC_RETENTION_MS));
-        TestUtils.createTopic(zkClient(), TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_NAME, METADATA_TOPIC_PARTITIONS_COUNT,
+        kafka.utils.TestUtils.createTopic(zkClient(), TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_NAME, METADATA_TOPIC_PARTITIONS_COUNT,
                               METADATA_TOPIC_REPLICATION_FACTOR, servers(), topicConfigs);
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.server.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicIdPartition;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.server.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.server.log.remote.storage.RemoteStorageException;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.LOG_DIR;
+import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP;
+
+public class TopicBasedRemoteLogMetadataManagerRestartTest {
+    private static final Logger log = LoggerFactory.getLogger(TopicBasedRemoteLogMetadataManagerRestartTest.class);
+
+    private static final int SEG_SIZE = 1024 * 1024;
+
+    private final Time time = new MockTime(1);
+    private final String logDir = TestUtils.tempDirectory("rlmm_segs").getAbsolutePath();
+    private final TopicBasedRemoteLogMetadataManagerHarness remoteLogMetadataManagerHarness = new TopicBasedRemoteLogMetadataManagerHarness() {
+        @Override
+        protected Map<String, Object> overrideRemoteLogMetadataManagerProps() {
+            Map<String, Object> props= new HashMap<>();
+            props.put(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP, 5000L);
+            props.put(LOG_DIR, logDir);
+            return props;
+        }
+    };
+
+    @BeforeEach
+    public void setup() {
+        // Start the cluster and initialize TopicBasedRemoteLogMetadataManager.
+        remoteLogMetadataManagerHarness.initialize(Collections.emptySet());
+    }
+
+    @AfterEach
+    public void teardown() throws IOException {
+        remoteLogMetadataManagerHarness.close();
+    }
+
+    public TopicBasedRemoteLogMetadataManager topicBasedRlmm() {
+        return remoteLogMetadataManagerHarness.topicBasedRlmm();
+    }
+
+    @Test
+    public void testRLMMAPIsAfterRestart() throws Exception {
+        // register partitions
+        // add segment metadata events.
+        // stop servers
+        // restart servers
+        // fetch the segment metadata added earlier.
+    }
+
+    @Test
+    public void testNewPartitionUpdates() throws Exception {
+        final TopicIdPartition newLeaderTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("new-leader", 0));
+        final TopicIdPartition newFollowerTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("new-follower", 0));
+
+        // Add segments for these partitions but they are not available as they have not yet been subscribed.
+        RemoteLogSegmentMetadata leaderSegmentMetadata = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(newLeaderTopicIdPartition, Uuid.randomUuid()),
+                                                                                0, 100, -1L, 0,
+                                                                                time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
+        topicBasedRlmm().addRemoteLogSegmentMetadata(leaderSegmentMetadata);
+
+        RemoteLogSegmentMetadata followerSegmentMetadata = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(newFollowerTopicIdPartition, Uuid.randomUuid()),
+                                                                                0, 100, -1L, 0,
+                                                                                time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
+        topicBasedRlmm().addRemoteLogSegmentMetadata(followerSegmentMetadata);
+
+        // `listRemoteLogSegments` will receive an exception as these topic partitions are not yet registered.
+        Assertions.assertThrows(RemoteStorageException.class, () -> topicBasedRlmm().listRemoteLogSegments(newLeaderTopicIdPartition));
+        Assertions.assertThrows(RemoteStorageException.class, () -> topicBasedRlmm().listRemoteLogSegments(newFollowerTopicIdPartition));
+
+        topicBasedRlmm().onPartitionLeadershipChanges(Collections.singleton(newLeaderTopicIdPartition),
+                                                      Collections.singleton(newFollowerTopicIdPartition));
+
+        waitUntilConsumerCatchesup(newLeaderTopicIdPartition, newFollowerTopicIdPartition, 30000L);
+
+        Assertions.assertTrue(topicBasedRlmm().listRemoteLogSegments(newLeaderTopicIdPartition).hasNext());
+        Assertions.assertTrue(topicBasedRlmm().listRemoteLogSegments(newFollowerTopicIdPartition).hasNext());
+    }
+
+    private void waitUntilConsumerCatchesup(TopicIdPartition newLeaderTopicIdPartition,
+                                            TopicIdPartition newFollowerTopicIdPartition,
+                                            long timeoutMs) throws TimeoutException {
+        int leaderMetadataPartition = topicBasedRlmm().metadataPartition(newLeaderTopicIdPartition);
+        int followerMetadataPartition = topicBasedRlmm().metadataPartition(newFollowerTopicIdPartition);
+
+        log.debug("Metadata partition for newLeaderTopicIdPartition: [{}], is: [{}]", newLeaderTopicIdPartition, leaderMetadataPartition);
+        log.debug("Metadata partition for newFollowerTopicIdPartition: [{}], is: [{}]", newFollowerTopicIdPartition, followerMetadataPartition);
+
+        long sleepMs = 100L;
+        long time = System.currentTimeMillis();
+
+        while (true) {
+            if (System.currentTimeMillis() - time > timeoutMs) {
+                throw new TimeoutException("Timed out after " + timeoutMs + "ms ");
+            }
+
+            if (leaderMetadataPartition == followerMetadataPartition) {
+                if (topicBasedRlmm().receivedOffsetForPartition(leaderMetadataPartition).orElse(-1L) > 0) {
+                    break;
+                }
+            } else {
+                if (topicBasedRlmm().receivedOffsetForPartition(leaderMetadataPartition).orElse(-1L) > -1 ||
+                        topicBasedRlmm().receivedOffsetForPartition(followerMetadataPartition).orElse(-1L) > -1) {
+                    break;
+                }
+            }
+
+            log.debug("Sleeping for: " + sleepMs);
+            Utils.sleep(sleepMs);
+        }
+    }
+
+}

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -52,7 +52,7 @@ public class TopicBasedRemoteLogMetadataManagerTest {
     @BeforeEach
     public void setup() {
         // Start the cluster and initialize TopicBasedRemoteLogMetadataManager.
-        remoteLogMetadataManagerHarness.initialize(Collections.emptySet());
+        remoteLogMetadataManagerHarness.initialize(Collections.emptySet(), true);
     }
 
     @AfterEach
@@ -61,7 +61,7 @@ public class TopicBasedRemoteLogMetadataManagerTest {
     }
 
     public TopicBasedRemoteLogMetadataManager topicBasedRlmm() {
-        return remoteLogMetadataManagerHarness.topicBasedRlmm();
+        return remoteLogMetadataManagerHarness.remoteLogMetadataManager();
     }
 
     @Test

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerTest.java
@@ -31,13 +31,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.Seq;
+import scala.jdk.CollectionConverters;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
-
-import static org.apache.kafka.server.log.remote.metadata.storage.TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP;
 
 public class TopicBasedRemoteLogMetadataManagerTest {
     private static final Logger log = LoggerFactory.getLogger(TopicBasedRemoteLogMetadataManagerTest.class);
@@ -45,12 +47,7 @@ public class TopicBasedRemoteLogMetadataManagerTest {
     private static final int SEG_SIZE = 1024 * 1024;
 
     private final Time time = new MockTime(1);
-    private final TopicBasedRemoteLogMetadataManagerHarness remoteLogMetadataManagerHarness = new TopicBasedRemoteLogMetadataManagerHarness() {
-        @Override
-        protected Map<String, Object> overrideRemoteLogMetadataManagerProps() {
-            return Collections.singletonMap(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP, 5000L);
-        }
-    };
+    private final TopicBasedRemoteLogMetadataManagerHarness remoteLogMetadataManagerHarness = new TopicBasedRemoteLogMetadataManagerHarness();
 
     @BeforeEach
     public void setup() {
@@ -68,19 +65,47 @@ public class TopicBasedRemoteLogMetadataManagerTest {
     }
 
     @Test
+    public void testWithNoAssignedPartitions() throws Exception {
+        // This test checks simple lifecycle of TopicBasedRemoteLogMetadataManager with out assigning any leader/follower partitions.
+        // This should close successfully releasing the resources.
+        log.info("Not assigning any partitions on TopicBasedRemoteLogMetadataManager");
+    }
+
+    @Test
     public void testNewPartitionUpdates() throws Exception {
-        final TopicIdPartition newLeaderTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("new-leader", 0));
-        final TopicIdPartition newFollowerTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("new-follower", 0));
+        // Create topics.
+        String leaderTopic = "new-leader";
+        HashMap<Object, Seq<Object>> assignedLeaderTopicReplicas = new HashMap<>();
+        List<Object> leaderTopicReplicas = new ArrayList<>();
+        // Set broker id 0 as the first entry which is taken as the leader.
+        leaderTopicReplicas.add(0);
+        leaderTopicReplicas.add(1);
+        leaderTopicReplicas.add(2);
+        assignedLeaderTopicReplicas.put(0, CollectionConverters.ListHasAsScala(leaderTopicReplicas).asScala());
+        remoteLogMetadataManagerHarness.createTopic(leaderTopic, CollectionConverters.MapHasAsScala(assignedLeaderTopicReplicas).asScala());
+
+        String followerTopic = "new-follower";
+        HashMap<Object, Seq<Object>> assignedFollowerTopicReplicas = new HashMap<>();
+        List<Object> followerTopicReplicas = new ArrayList<>();
+        // Set broker id 1 as the first entry which is taken as the leader.
+        followerTopicReplicas.add(1);
+        followerTopicReplicas.add(2);
+        followerTopicReplicas.add(0);
+        assignedFollowerTopicReplicas.put(0, CollectionConverters.ListHasAsScala(followerTopicReplicas).asScala());
+        remoteLogMetadataManagerHarness.createTopic(followerTopic, CollectionConverters.MapHasAsScala(assignedFollowerTopicReplicas).asScala());
+
+        final TopicIdPartition newLeaderTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition(leaderTopic, 0));
+        final TopicIdPartition newFollowerTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition(followerTopic, 0));
 
         // Add segments for these partitions but they are not available as they have not yet been subscribed.
         RemoteLogSegmentMetadata leaderSegmentMetadata = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(newLeaderTopicIdPartition, Uuid.randomUuid()),
-                                                                                0, 100, -1L, 0,
-                                                                                time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
+                                                                                      0, 100, -1L, 0,
+                                                                                      time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
         topicBasedRlmm().addRemoteLogSegmentMetadata(leaderSegmentMetadata);
 
         RemoteLogSegmentMetadata followerSegmentMetadata = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(newFollowerTopicIdPartition, Uuid.randomUuid()),
-                                                                                0, 100, -1L, 0,
-                                                                                time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
+                                                                                        0, 100, -1L, 0,
+                                                                                        time.milliseconds(), SEG_SIZE, Collections.singletonMap(0, 0L));
         topicBasedRlmm().addRemoteLogSegmentMetadata(followerSegmentMetadata);
 
         // `listRemoteLogSegments` will receive an exception as these topic partitions are not yet registered.
@@ -90,15 +115,15 @@ public class TopicBasedRemoteLogMetadataManagerTest {
         topicBasedRlmm().onPartitionLeadershipChanges(Collections.singleton(newLeaderTopicIdPartition),
                                                       Collections.singleton(newFollowerTopicIdPartition));
 
-        waitUntilConsumerCatchesup(newLeaderTopicIdPartition, newFollowerTopicIdPartition, 30000L);
+        waitUntilConsumerCatchup(newLeaderTopicIdPartition, newFollowerTopicIdPartition, 300_000L);
 
         Assertions.assertTrue(topicBasedRlmm().listRemoteLogSegments(newLeaderTopicIdPartition).hasNext());
         Assertions.assertTrue(topicBasedRlmm().listRemoteLogSegments(newFollowerTopicIdPartition).hasNext());
     }
 
-    private void waitUntilConsumerCatchesup(TopicIdPartition newLeaderTopicIdPartition,
-                                            TopicIdPartition newFollowerTopicIdPartition,
-                                            long timeoutMs) throws TimeoutException {
+    private void waitUntilConsumerCatchup(TopicIdPartition newLeaderTopicIdPartition,
+                                          TopicIdPartition newFollowerTopicIdPartition,
+                                          long timeoutMs) throws TimeoutException {
         int leaderMetadataPartition = topicBasedRlmm().metadataPartition(newLeaderTopicIdPartition);
         int followerMetadataPartition = topicBasedRlmm().metadataPartition(newFollowerTopicIdPartition);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerWrapperWithHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerWrapperWithHarness.java
@@ -76,6 +76,7 @@ public class TopicBasedRemoteLogMetadataManagerWrapperWithHarness implements Rem
     @Override
     public void onPartitionLeadershipChanges(Set<TopicIdPartition> leaderPartitions,
                                              Set<TopicIdPartition> followerPartitions) {
+
         remoteLogMetadataManagerHarness.topicBasedRlmm().onPartitionLeadershipChanges(leaderPartitions, followerPartitions);
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerWrapperWithHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerWrapperWithHarness.java
@@ -36,64 +36,64 @@ public class TopicBasedRemoteLogMetadataManagerWrapperWithHarness implements Rem
 
     @Override
     public void addRemoteLogSegmentMetadata(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException {
-        remoteLogMetadataManagerHarness.topicBasedRlmm().addRemoteLogSegmentMetadata(remoteLogSegmentMetadata);
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().addRemoteLogSegmentMetadata(remoteLogSegmentMetadata);
     }
 
     @Override
     public void updateRemoteLogSegmentMetadata(RemoteLogSegmentMetadataUpdate remoteLogSegmentMetadataUpdate) throws RemoteStorageException {
-        remoteLogMetadataManagerHarness.topicBasedRlmm().updateRemoteLogSegmentMetadata(remoteLogSegmentMetadataUpdate);
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().updateRemoteLogSegmentMetadata(remoteLogSegmentMetadataUpdate);
     }
 
     @Override
     public Optional<RemoteLogSegmentMetadata> remoteLogSegmentMetadata(TopicIdPartition topicIdPartition,
                                                                        int epochForOffset,
                                                                        long offset) throws RemoteStorageException {
-        return remoteLogMetadataManagerHarness.topicBasedRlmm().remoteLogSegmentMetadata(topicIdPartition, epochForOffset, offset);
+        return remoteLogMetadataManagerHarness.remoteLogMetadataManager().remoteLogSegmentMetadata(topicIdPartition, epochForOffset, offset);
     }
 
     @Override
     public Optional<Long> highestOffsetForEpoch(TopicIdPartition topicIdPartition,
                                                 int leaderEpoch) throws RemoteStorageException {
-        return remoteLogMetadataManagerHarness.topicBasedRlmm().highestOffsetForEpoch(topicIdPartition, leaderEpoch);
+        return remoteLogMetadataManagerHarness.remoteLogMetadataManager().highestOffsetForEpoch(topicIdPartition, leaderEpoch);
     }
 
     @Override
     public void putRemotePartitionDeleteMetadata(RemotePartitionDeleteMetadata remotePartitionDeleteMetadata) throws RemoteStorageException {
-        remoteLogMetadataManagerHarness.topicBasedRlmm().putRemotePartitionDeleteMetadata(remotePartitionDeleteMetadata);
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().putRemotePartitionDeleteMetadata(remotePartitionDeleteMetadata);
     }
 
     @Override
     public Iterator<RemoteLogSegmentMetadata> listRemoteLogSegments(TopicIdPartition topicIdPartition) throws RemoteStorageException {
-        return remoteLogMetadataManagerHarness.topicBasedRlmm().listRemoteLogSegments(topicIdPartition);
+        return remoteLogMetadataManagerHarness.remoteLogMetadataManager().listRemoteLogSegments(topicIdPartition);
     }
 
     @Override
     public Iterator<RemoteLogSegmentMetadata> listRemoteLogSegments(TopicIdPartition topicIdPartition,
                                                                     int leaderEpoch) throws RemoteStorageException {
-        return remoteLogMetadataManagerHarness.topicBasedRlmm().listRemoteLogSegments(topicIdPartition, leaderEpoch);
+        return remoteLogMetadataManagerHarness.remoteLogMetadataManager().listRemoteLogSegments(topicIdPartition, leaderEpoch);
     }
 
     @Override
     public void onPartitionLeadershipChanges(Set<TopicIdPartition> leaderPartitions,
                                              Set<TopicIdPartition> followerPartitions) {
 
-        remoteLogMetadataManagerHarness.topicBasedRlmm().onPartitionLeadershipChanges(leaderPartitions, followerPartitions);
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().onPartitionLeadershipChanges(leaderPartitions, followerPartitions);
     }
 
     @Override
     public void onStopPartitions(Set<TopicIdPartition> partitions) {
-        remoteLogMetadataManagerHarness.topicBasedRlmm().onStopPartitions(partitions);
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().onStopPartitions(partitions);
     }
 
     @Override
     public void close() throws IOException {
-        remoteLogMetadataManagerHarness.topicBasedRlmm().close();
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().close();
     }
 
     @Override
     public void configure(Map<String, ?> configs) {
         // This will make sure the cluster is up and TopicBasedRemoteLogMetadataManager is initialized.
-        remoteLogMetadataManagerHarness.initialize(Collections.emptySet());
-        remoteLogMetadataManagerHarness.topicBasedRlmm().configure(configs);
+        remoteLogMetadataManagerHarness.initialize(Collections.emptySet(), true);
+        remoteLogMetadataManagerHarness.remoteLogMetadataManager().configure(configs);
     }
 }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManagerTest.java
@@ -88,7 +88,6 @@ public class RemoteLogMetadataManagerTest {
             remoteLogMetadataManager.configure(Collections.emptyMap());
             remoteLogMetadataManager.onPartitionLeadershipChanges(Collections.singleton(TP0), Collections.emptySet());
 
-
             // Create remote log segment metadata and add them to RLMM.
 
             // segment 0


### PR DESCRIPTION
- Added file based remote log metadata snapshots.
- Fixed a few issues in snapshot read/write/load and added tests.
- Added TopicBasedRemoteLogMetadataManagerRestartTest and fixed issues in reloading the snapshots.
   - TopicBasedRemoteLogMetadataManagerRestartTest is about verifying
     - load the earlier saved snapshots after restart
     - check the entries are available
     - start the consumer and add more metadata entries
     - check the newly addded entries and loaded entries are available