### PR TITLE
Added transformation of TopicIdPartition into bytes with custom hashing.

### DIFF
--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -65,14 +65,14 @@ class RemoteLogManagerTest {
 
   val rlmConfig: RemoteLogManagerConfig = {
     val props = new Properties
-    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, true)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, true.toString)
     props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, rsmConfigPrefix)
     props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, rlmmConfigPrefix)
     props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteStorageManager")
     props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteLogMetadataManager")
-    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, 2)
-    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, 10)
-    rsmConfig.foreach(config => props.put(config._1, config._2))
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, 2.toString)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, 10.toString)
+    rsmConfig.foreach(config => props.put(config._1, config._2.toString))
     val config = new AbstractConfig(RemoteLogManagerConfig.CONFIG_DEF, props, false)
     new RemoteLogManagerConfig(config)
   }

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
@@ -162,13 +162,13 @@ object MockRemoteLogManager {
 
   def rlmConfig(threads: Int, taskQueueSize: Int): RemoteLogManagerConfig = {
     val props = new Properties
-    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, true)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_STORAGE_SYSTEM_ENABLE_PROP, true.toString)
     props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CONFIG_PREFIX_PROP, "rlmm.config.")
     props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX_PROP, "rsm.config.")
     props.put(RemoteLogManagerConfig.REMOTE_STORAGE_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteStorageManager")
     props.put(RemoteLogManagerConfig.REMOTE_LOG_METADATA_MANAGER_CLASS_NAME_PROP, "kafka.log.remote.MockRemoteLogMetadataManager")
-    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, threads)
-    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, taskQueueSize)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_THREADS_PROP, threads.toString)
+    props.put(RemoteLogManagerConfig.REMOTE_LOG_READER_MAX_PENDING_TASKS_PROP, taskQueueSize.toString)
     val config = new AbstractConfig(RemoteLogManagerConfig.CONFIG_DEF, props, false)
     new RemoteLogManagerConfig(config)
   }

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataTopicPartitioner.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogMetadataTopicPartitioner.java
@@ -25,25 +25,24 @@ import java.util.Objects;
 
 public class RemoteLogMetadataTopicPartitioner {
     public static final Logger log = LoggerFactory.getLogger(RemoteLogMetadataTopicPartitioner.class);
-    private final int noOfMetadataTopicPartitions;
+    private final int numMetadataTopicPartitions;
 
-    public RemoteLogMetadataTopicPartitioner(int noOfMetadataTopicPartitions) {
-        this.noOfMetadataTopicPartitions = noOfMetadataTopicPartitions;
+    public RemoteLogMetadataTopicPartitioner(int numMetadataTopicPartitions) {
+        this.numMetadataTopicPartitions = numMetadataTopicPartitions;
     }
 
     public int metadataPartition(TopicIdPartition topicIdPartition) {
         Objects.requireNonNull(topicIdPartition, "TopicPartition can not be null");
 
-        int partitionNo = Utils.toPositive(Utils.murmur2(toBytes(topicIdPartition))) % noOfMetadataTopicPartitions;
-        log.debug("No of partitions [{}], partitionNo: [{}] for given topic: [{}]", noOfMetadataTopicPartitions, partitionNo, topicIdPartition);
-        return partitionNo;
+        int partitionNum = Utils.toPositive(Utils.murmur2(toBytes(topicIdPartition))) % numMetadataTopicPartitions;
+        log.debug("No of partitions [{}], partitionNum: [{}] for given topic: [{}]", numMetadataTopicPartitions, partitionNum, topicIdPartition);
+        return partitionNum;
     }
 
     private byte[] toBytes(TopicIdPartition topicIdPartition) {
         // We do not want to depend upon hash code generation of Uuid as that may change.
         int hash = Objects.hash(topicIdPartition.topicId().getLeastSignificantBits(),
                                 topicIdPartition.topicId().getMostSignificantBits(),
-                                topicIdPartition.topicPartition().topic(),
                                 topicIdPartition.topicPartition().partition());
 
         return toBytes(hash);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/RemotePartitionMetadataStore.java
@@ -39,6 +39,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * This class represents a store to maintain the {@link RemotePartitionDeleteMetadata} and {@link RemoteLogMetadataCache} for each topic partition.
+ */
 public class RemotePartitionMetadataStore extends RemotePartitionMetadataEventHandler implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(RemotePartitionMetadataStore.class);
 
@@ -84,7 +87,7 @@ public class RemotePartitionMetadataStore extends RemotePartitionMetadataEventHa
             try {
                 remoteLogMetadataCache.updateRemoteLogSegmentMetadata(rlsmUpdate);
             } catch (RemoteResourceNotFoundException e) {
-                log.error("Error occurred while updating the remote logs segment.");
+                log.error("Error occurred while updating the remote log segment.");
             }
         } else {
             log.error("No partition metadata found for : " + topicIdPartition);

--- a/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
+++ b/storage/src/main/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfig.java
@@ -38,6 +38,9 @@ import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
 import static org.apache.kafka.common.config.ConfigDef.Type.SHORT;
 import static org.apache.kafka.common.internals.Topic.REMOTE_LOG_METADATA_TOPIC_NAME;
 
+/**
+ * This class defines the configuration of topic based {@link org.apache.kafka.server.log.remote.storage.RemoteLogMetadataManager} implementation.
+ */
 public final class TopicBasedRemoteLogMetadataManagerConfig {
     private static final Logger log = LoggerFactory.getLogger(TopicBasedRemoteLogMetadataManagerConfig.class.getName());
 
@@ -49,7 +52,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     public static final int DEFAULT_REMOTE_LOG_METADATA_TOPIC_PARTITIONS = 50;
     public static final long DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS = -1L;
     public static final short DEFAULT_REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR = 3;
-    public static final long DEFAULT_REMOTE_LOG_METADATA_CONSUME_WAIT_MS = 60 * 1000L;
+    public static final long DEFAULT_REMOTE_LOG_METADATA_CONSUME_WAIT_MS = 120 * 1000L;
 
     public static final String REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_DOC = "Replication factor of remote log metadata Topic.";
     public static final String REMOTE_LOG_METADATA_TOPIC_PARTITIONS_DOC = "The number of partitions for remote log metadata Topic.";
@@ -82,11 +85,11 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
     private final String clientIdPrefix;
     private final int metadataTopicPartitionsCount;
-    private final short replicationFactor;
     private final String bootstrapServers;
     private final String logDir;
     private final long consumeWaitMs;
-    private final long metadataTopicRetentionMillis;
+    private final long metadataTopicRetentionMs;
+    private final short metadataTopicReplicationFactor;
 
     private Map<String, Object> consumerProps;
     private Map<String, Object> producerProps;
@@ -110,10 +113,10 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
 
         consumeWaitMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_CONSUME_WAIT_MS_PROP);
         metadataTopicPartitionsCount = (int) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP);
-        replicationFactor = (short) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP);
-        metadataTopicRetentionMillis = (long) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS_PROP);
-        if (metadataTopicRetentionMillis != -1 && metadataTopicRetentionMillis <= 0) {
-            throw new IllegalArgumentException("Invalid metadata topic retention in millis: " + metadataTopicRetentionMillis);
+        metadataTopicReplicationFactor = (short) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP);
+        metadataTopicRetentionMs = (long) parsedConfigs.get(REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS_PROP);
+        if (metadataTopicRetentionMs != -1 && metadataTopicRetentionMs <= 0) {
+            throw new IllegalArgumentException("Invalid metadata topic retention in millis: " + metadataTopicRetentionMs);
         }
 
         clientIdPrefix = REMOTE_LOG_METADATA_CLIENT_PREFIX + "_" + props.get(BROKER_ID);
@@ -157,7 +160,11 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
     }
 
     public short metadataTopicReplicationFactor() {
-        return replicationFactor;
+        return metadataTopicReplicationFactor;
+    }
+
+    public long metadataTopicRetentionMs() {
+        return metadataTopicRetentionMs;
     }
 
     public long consumeWaitMs() {
@@ -207,7 +214,7 @@ public final class TopicBasedRemoteLogMetadataManagerConfig {
                 ", metadataTopicPartitionsCount=" + metadataTopicPartitionsCount +
                 ", bootstrapServers='" + bootstrapServers + '\'' +
                 ", consumeWaitMs=" + consumeWaitMs +
-                ", metadataTopicRetentionMillis=" + metadataTopicRetentionMillis +
+                ", metadataTopicRetentionMillis=" + metadataTopicRetentionMs +
                 ", consumerProps=" + consumerProps +
                 ", producerProps=" + producerProps +
                 '}';

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleManager.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleManager.java
@@ -30,6 +30,9 @@ import java.util.Optional;
  * This interface defines the lifecycle methods for {@code RemoteLogSegmentMetadata}. {@link RemoteLogSegmentLifecycleTest} tests
  * different implementations of this interface. This is responsible for managing all the segments for a given {@code topicIdPartition}
  * registered with {@link #initialize(TopicIdPartition)}.
+ *
+ * @see org.apache.kafka.server.log.remote.metadata.storage.RemoteLogSegmentLifecycleTest.RemoteLogMetadataCacheWrapper
+ * @see org.apache.kafka.server.log.remote.metadata.storage.RemoteLogSegmentLifecycleTest.TopicBasedRemoteLogMetadataManagerWrapper
  */
 public interface RemoteLogSegmentLifecycleManager extends Closeable {
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/RemoteLogSegmentLifecycleTest.java
@@ -85,8 +85,7 @@ public class RemoteLogSegmentLifecycleTest {
             // it reaches RemoteLogSegmentState.COPY_SEGMENT_FINISHED.
             assertFalse(remoteLogSegmentLifecycleManager.remoteLogSegmentMetadata(40, 1).isPresent());
 
-            // Check that these leader epochs are to considered for highest offsets as they are still getting copied and
-            // they did nto reach COPY_SEGMENT_FINISHED state.
+            // Check that these leader epochs are not to be considered for highestOffsetForEpoch API as they are still getting copied.
             Stream.of(0, 1, 2).forEach(epoch -> {
                 try {
                     assertFalse(remoteLogSegmentLifecycleManager.highestOffsetForEpoch(epoch).isPresent());
@@ -424,7 +423,7 @@ public class RemoteLogSegmentLifecycleTest {
      * creates the remote log metadata topic required for {@code TopicBasedRemoteLogMetadataManager}. This cluster will
      * be stopped by invoking {@link #close()}.
      */
-    private static class TopicBasedRemoteLogMetadataManagerWrapper extends TopicBasedRemoteLogMetadataManagerHarness implements RemoteLogSegmentLifecycleManager {
+    static class TopicBasedRemoteLogMetadataManagerWrapper extends TopicBasedRemoteLogMetadataManagerHarness implements RemoteLogSegmentLifecycleManager {
 
         private TopicIdPartition topicIdPartition;
 
@@ -481,7 +480,7 @@ public class RemoteLogSegmentLifecycleTest {
      * This is passed to {@link #testRemoteLogSegmentLifeCycle(RemoteLogSegmentLifecycleManager)} to test
      * {@code RemoteLogMetadataCache} for several lifecycle operations.
      */
-    private static class RemoteLogMetadataCacheWrapper implements RemoteLogSegmentLifecycleManager {
+    static class RemoteLogMetadataCacheWrapper implements RemoteLogSegmentLifecycleManager {
 
         private final RemoteLogMetadataCache metadataCache = new RemoteLogMetadataCache();
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfigTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerConfigTest.java
@@ -76,7 +76,7 @@ public class TopicBasedRemoteLogMetadataManagerConfigTest {
             Assertions.assertEquals(entry.getValue(),
                                     rlmmConfig.producerProperties().get(entry.getKey()));
             Assertions.assertEquals(entry.getValue(),
-                                    rlmmConfig.producerProperties().get(entry.getKey()));
+                                    rlmmConfig.consumerProperties().get(entry.getKey()));
         }
 
         // Check for producer configs.
@@ -129,7 +129,7 @@ public class TopicBasedRemoteLogMetadataManagerConfigTest {
         props.put(BROKER_ID, 1);
         props.put(LOG_DIR, TestUtils.tempDirectory().getAbsolutePath());
 
-        props.put(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP, 3);
+        props.put(REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP, (short) 3);
         props.put(REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP, 10);
         props.put(REMOTE_LOG_METADATA_TOPIC_RETENTION_MILLIS_PROP, 60 * 60 * 1000L);
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerHarness.java
@@ -21,8 +21,6 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicIdPartition;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,10 +48,9 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
     private static final Logger log = LoggerFactory.getLogger(TopicBasedRemoteLogMetadataManagerHarness.class);
 
     protected static final int METADATA_TOPIC_PARTITIONS_COUNT = 3;
-    protected static final int METADATA_TOPIC_REPLICATION_FACTOR = 2;
+    protected static final short METADATA_TOPIC_REPLICATION_FACTOR = 2;
     protected static final long METADATA_TOPIC_RETENTION_MS = 24 * 60 * 60 * 1000L;
 
-    private final Time time = new MockTime(1);
     private TopicBasedRemoteLogMetadataManager topicBasedRemoteLogMetadataManager;
 
     protected final Map<String, Object> overrideRemoteLogMetadataManagerProps = new HashMap<>();
@@ -63,16 +60,13 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
         // Call setup to start the cluster.
         super.setUp();
 
-        // Make sure the remote log metadata topic is created before it is used.
-        createMetadataTopic();
-
         initializeRemoteLogMetadataManager(topicIdPartitions, startConsumerThread);
     }
 
     public void initializeRemoteLogMetadataManager(Set<TopicIdPartition> topicIdPartitions,
                                                    boolean startConsumerThread) {
         String logDir = org.apache.kafka.test.TestUtils.tempDirectory("rlmm_segs_").getAbsolutePath();
-        topicBasedRemoteLogMetadataManager = new TopicBasedRemoteLogMetadataManager(time, startConsumerThread) {
+        topicBasedRemoteLogMetadataManager = new TopicBasedRemoteLogMetadataManager(startConsumerThread) {
             @Override
             public void onPartitionLeadershipChanges(Set<TopicIdPartition> leaderPartitions,
                                                      Set<TopicIdPartition> followerPartitions) {
@@ -125,7 +119,7 @@ public class TopicBasedRemoteLogMetadataManagerHarness extends IntegrationTestHa
                 throw new TimeoutException("Time out reached before it is initialized successfully");
             }
 
-            Utils.sleep(1000);
+            Utils.sleep(100);
         }
     }
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/metadata/storage/TopicBasedRemoteLogMetadataManagerRestartTest.java
@@ -45,7 +45,7 @@ public class TopicBasedRemoteLogMetadataManagerRestartTest {
     private static final int SEG_SIZE = 1024 * 1024;
 
     private final Time time = new MockTime(1);
-    private String logDir = TestUtils.tempDirectory("_rlmm_segs_").getAbsolutePath();
+    private final String logDir = TestUtils.tempDirectory("_rlmm_segs_").getAbsolutePath();
 
     private TopicBasedRemoteLogMetadataManagerHarness remoteLogMetadataManagerHarness;
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/LocalTieredStorage.java
@@ -100,8 +100,6 @@ import static org.apache.kafka.server.log.remote.storage.RemoteTopicPartitionDir
  */
 public final class LocalTieredStorage implements RemoteStorageManager {
 
-    InputStream EMPTY_INPUT_STREAM = new ByteArrayInputStream(new byte[0]);
-
     public static final String STORAGE_CONFIG_PREFIX = "remote.log.storage.local.";
 
     /**
@@ -374,7 +372,7 @@ public final class LocalTieredStorage implements RemoteStorageManager {
 
                 File file = fileset.getFile(fileType);
                 final InputStream inputStream = (fileType.isOptional() && !file.exists()) ?
-                        EMPTY_INPUT_STREAM : newInputStream(file.toPath(), READ);
+                        new ByteArrayInputStream(new byte[0]) : newInputStream(file.toPath(), READ);
 
                 storageListeners.onStorageEvent(eventBuilder.withFileset(fileset).build());
 

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManagerTest.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogMetadataManagerTest.java
@@ -146,7 +146,6 @@ public class RemoteLogMetadataManagerTest {
     }
 
     private static Collection<Arguments> remoteLogMetadataManagers() {
-        return Arrays.asList(Arguments.of(new InmemoryRemoteLogMetadataManager()),
-                             Arguments.of(new TopicBasedRemoteLogMetadataManagerWrapperWithHarness()));
+        return Arrays.asList(Arguments.of(new InmemoryRemoteLogMetadataManager()), Arguments.of(new TopicBasedRemoteLogMetadataManagerWrapperWithHarness()));
     }
 }

--- a/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentFileset.java
+++ b/storage/src/test/java/org/apache/kafka/server/log/remote/storage/RemoteLogSegmentFileset.java
@@ -41,7 +41,13 @@ import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.regex.Pattern.compile;
 import static java.util.stream.Collectors.toMap;
-import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.*;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.LEADER_EPOCH_CHECKPOINT;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.OFFSET_INDEX;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.PRODUCER_SNAPSHOT;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.SEGMENT;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.TIME_INDEX;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.TRANSACTION_INDEX;
+import static org.apache.kafka.server.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.getFileType;
 import static org.apache.kafka.server.log.remote.storage.RemoteTopicPartitionDirectory.openTopicPartitionDirectory;
 import static org.slf4j.LoggerFactory.getLogger;
 

--- a/storage/src/test/resources/log4j.properties
+++ b/storage/src/test/resources/log4j.properties
@@ -19,3 +19,4 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.kafka.server.log.remote.storage=INFO
+log4j.logger.org.apache.kafka.server.log.remote.metadata.storage=INFO


### PR DESCRIPTION
Skipping the events which are not currently assigned for the ConsumerTask.
Introduced exceptions instead of ignoring in cases like
   - timeouts
   - if the published message's partition is not yet subscribed by RLMM yet

