### PR TITLE
Fix log message during local log segment deletion

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2007,13 +2007,12 @@ class Log(@volatile private var _dir: File,
     }
   }
 
+  private[log] def localRetentionMs: Long = {
+    if(config.remoteStorageEnable) config.localRetentionMs else config.retentionMs
+  }
+
   private def deleteRetentionMsBreachedSegments(): Int = {
-
-    def localRetentionMs(): Long = {
-      if(config.remoteStorageEnable) config.localRetentionMs else config.retentionMs
-    }
-
-    val retentionMs = localRetentionMs()
+    val retentionMs = localRetentionMs
     if (retentionMs < 0) return 0
     val startMs = time.milliseconds
 
@@ -2024,13 +2023,12 @@ class Log(@volatile private var _dir: File,
     deleteOldSegments(shouldDelete, RetentionMsBreach)
   }
 
+  private[log] def localRetentionSize: Long = {
+    if (config.remoteStorageEnable) config.localRetentionBytes else config.retentionSize
+  }
+
   private def deleteRetentionSizeBreachedSegments(): Int = {
-
-    def localRetentionSize(): Long = {
-      if(config.remoteStorageEnable) config.localRetentionBytes else config.retentionSize
-    }
-
-    val retentionSize:Long = localRetentionSize()
+    val retentionSize: Long = localRetentionSize
     if (retentionSize < 0 || size < retentionSize) return 0
     var diff = size - retentionSize
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]): Boolean = {
@@ -2952,7 +2950,7 @@ sealed trait SegmentDeletionReason {
 
 case object RetentionMsBreach extends SegmentDeletionReason {
   override def logReason(log: Log, toDelete: List[LogSegment]): Unit = {
-    val retentionMs = log.config.retentionMs
+    val retentionMs = log.localRetentionMs
     toDelete.foreach { segment =>
       segment.largestRecordTimestamp match {
         case Some(_) =>
@@ -2968,10 +2966,11 @@ case object RetentionMsBreach extends SegmentDeletionReason {
 
 case object RetentionSizeBreach extends SegmentDeletionReason {
   override def logReason(log: Log, toDelete: List[LogSegment]): Unit = {
+    val retentionSize = log.localRetentionSize
     var size = log.size
     toDelete.foreach { segment =>
       size -= segment.size
-      log.info(s"Deleting segment $segment due to retention size ${log.config.retentionSize} breach. Log size " +
+      log.info(s"Deleting segment $segment due to retention size $retentionSize breach. Log size " +
         s"after deletion will be $size.")
     }
   }


### PR DESCRIPTION
Fix log message during local log segment deletion to use `localLogRetentionMs` or `localLogRetentionBytes` config.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
