### PR TITLE
Transaction index may be missing in remote tier, handle in RemoteIndexCache

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -16,7 +16,7 @@
  */
 package kafka.log.remote
 
-import java.io.{File, InputStream}
+import java.io.{ByteArrayInputStream, File, InputStream}
 import java.nio.file.{Files, Path}
 import java.util
 import java.util.concurrent.LinkedBlockingQueue
@@ -26,7 +26,7 @@ import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.errors.CorruptRecordException
 import org.apache.kafka.common.utils.{KafkaThread, Utils}
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
-import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteStorageManager}
+import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteResourceNotFoundException, RemoteStorageManager}
 
 object RemoteIndexCache {
   val DirName = "remote-log-index-cache"
@@ -127,21 +127,26 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
   def getIndexEntry(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Entry = {
     def loadIndexFile[T <: CleanableIndex](fileName: String,
                                            suffix: String,
-                                           fetchRemoteIndex: RemoteLogSegmentMetadata => InputStream,
+                                           fetchRemoteIndex: RemoteLogSegmentMetadata => Option[InputStream],
                                            readIndex: File => T): T = {
       val indexFile = new File(cacheDir, fileName + suffix)
+      var inputStreamIsEmpty: Boolean = false
 
       def fetchAndCreateIndex(): T = {
         val inputStream = fetchRemoteIndex(remoteLogSegmentMetadata)
-        val tmpIndexFile = new File(cacheDir, fileName + suffix + RemoteIndexCache.TmpFileSuffix)
+        inputStreamIsEmpty = inputStream.isEmpty
+        inputStream.foreach(inputStream => {
+          val tmpIndexFile = new File(cacheDir, fileName + suffix + RemoteIndexCache.TmpFileSuffix)
 
-        Files.copy(inputStream, tmpIndexFile.toPath)
+          Files.copy(inputStream, tmpIndexFile.toPath)
 
-        Utils.atomicMoveWithFallback(tmpIndexFile.toPath, indexFile.toPath)
+          Utils.atomicMoveWithFallback(tmpIndexFile.toPath, indexFile.toPath)
+        })
+
         readIndex(indexFile)
       }
 
-      if (indexFile.exists()) {
+      if (inputStreamIsEmpty || indexFile.exists()) {
         try {
           readIndex(indexFile)
         } catch {
@@ -160,7 +165,7 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
         val startOffset = remoteLogSegmentMetadata.startOffset()
 
         val offsetIndex: OffsetIndex = loadIndexFile(fileName, RemoteIndexCache.OffsetIndexFileSuffix,
-          rlsMetadata => remoteStorageManager.fetchIndex(rlsMetadata, IndexType.OFFSET),
+          rlsMetadata => Option(remoteStorageManager.fetchIndex(rlsMetadata, IndexType.OFFSET)),
           file => {
             val index = new OffsetIndex(file, startOffset, Int.MaxValue, writable = false)
             index.sanityCheck()
@@ -168,15 +173,23 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
           })
 
         val timeIndex: TimeIndex = loadIndexFile(fileName, RemoteIndexCache.TimeIndexFileSuffix,
-          rlsMetadata => remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TIMESTAMP),
+          rlsMetadata => Option(remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TIMESTAMP)),
           file => {
             val index = new TimeIndex(file, startOffset, Int.MaxValue, writable = false)
             index.sanityCheck()
             index
           })
 
+        def fetchTransactionIndex(rlsMetadata: RemoteLogSegmentMetadata): Option[InputStream] = {
+          try {
+            Option(remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TRANSACTION))
+          } catch {
+            case _: RemoteResourceNotFoundException => None
+          }
+        }
+
         val txnIndex: TransactionIndex = loadIndexFile(fileName, RemoteIndexCache.TxnIndexFileSuffix,
-          rlsMetadata => remoteStorageManager.fetchIndex(rlsMetadata, IndexType.TRANSACTION),
+          fetchTransactionIndex,
           file => {
             val index = new TransactionIndex(startOffset, file)
             index.sanityCheck()

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -16,7 +16,7 @@
  */
 package kafka.log.remote
 
-import java.io.{ByteArrayInputStream, File, InputStream}
+import java.io.{File, InputStream}
 import java.nio.file.{Files, Path}
 import java.util
 import java.util.concurrent.LinkedBlockingQueue


### PR DESCRIPTION
Currently, if a transaction index file doesn't exist, the `RemoteIndexCache` fails and throws an exception trying to fetch it. It is likely not to have a transaction index at all for segments that are not being written with read_committed isolation. In this scenario, the `RemoteIndexCache` should  handle the `RemoteResourceNotFoundException` gracefully for the transaction index.

This does not surface in the current integration tests (and possibly testing at Uber with the HDFS RSM) because neither the HDFS RSM nor the `LocalTieredStorage` used for integration tests throw `RemoteResourceNotFoundException` when a transaction index is not found, choosing rather to return a zero-length InputStream. The API contract for RSM however, expects the `RemoteResourceNotFoundException` to be thrown in this scenario.

https://github.com/satishd/kafka/blob/c3a084e84cbf9582327f81b80413b2c275e20b6f/storage/api/src/main/java/org/apache/kafka/server/log/remote/storage/RemoteStorageManager.java#L123-L126

* If transaction index is not present in remote tier, handle exception and create new index backed by a non-existent file.
  In a non-remote scenario, TransactionIndex is supposed to be present for every LogSegment instance, but it need not be backed by a file. It only creates the file when transactions are appended.
* Added integration tests to verify that there is no exception when `TransactionIndex` throws a `RemoteResourceNotFoundException` exception.
* Remove unused stubbing for `PRODUCER_SNAPSHOT` in RemoteIndexCacheTest. This was causing EasyMock.verify() call to fail.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
