### PR TITLE
Follower Fetch rlsMetadata at ELO - 1 and the corresponding leader epoch

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -98,11 +98,12 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def fetchFromLeader(fetchRequest: FetchRequest.Builder): Map[TopicPartition, FetchData]
 
-  protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long
+  protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): (Int, Long)
 
   protected def fetchLatestOffsetFromLeader(topicPartition: TopicPartition, currentLeaderEpoch: Int): Long
 
-  protected def buildRemoteLogAuxState(partition: TopicPartition, currentLeaderEpoch: Int, fetchOffset: Long, leaderLogStartOffset: Long): Unit
+  protected def buildRemoteLogAuxState(partition: TopicPartition, currentLeaderEpoch: Int, fetchOffset: Long,
+                                       epochForLeaderLocalLogStartOffset: Int, leaderLogStartOffset: Long): Unit
 
   protected val isOffsetForLeaderEpochSupported: Boolean
 
@@ -637,7 +638,7 @@ abstract class AbstractFetcherThread(name: String,
 
   private def fetchOffsetAndApplyFun(topicPartition: TopicPartition,
                                      currentLeaderEpoch: Int,
-                                     truncateAndBuild: => Long => Unit) : PartitionFetchState = {
+                                     truncateAndBuild: => (Int, Long) => Unit) : PartitionFetchState = {
     val replicaEndOffset = logEndOffset(topicPartition)
 
     /**
@@ -681,13 +682,13 @@ abstract class AbstractFetcherThread(name: String,
        * Putting the two cases together, the follower should fetch from the higher one of its replica log end offset
        * and the current leader's log start offset.
        */
-      val leaderStartOffset = fetchEarliestOffsetFromLeader(topicPartition, currentLeaderEpoch)
+      val (leaderEpoch, leaderStartOffset) = fetchEarliestOffsetFromLeader(topicPartition, currentLeaderEpoch)
       warn(s"Reset fetch offset for partition $topicPartition from $replicaEndOffset to current " +
         s"leader's start offset $leaderStartOffset")
       val offsetToFetch = Math.max(leaderStartOffset, replicaEndOffset)
       // Only truncate log when current leader's log start offset is greater than follower's log end offset.
       if (leaderStartOffset > replicaEndOffset) {
-        truncateAndBuild(leaderStartOffset)
+        truncateAndBuild(leaderEpoch, leaderStartOffset)
       }
 
       val initialLag = leaderEndOffset - offsetToFetch
@@ -702,7 +703,7 @@ abstract class AbstractFetcherThread(name: String,
    */
   protected def fetchOffsetAndTruncate(topicPartition: TopicPartition, currentLeaderEpoch: Int): PartitionFetchState = {
     fetchOffsetAndApplyFun(topicPartition, currentLeaderEpoch,
-      leaderLogStartOffset => truncateFullyAndStartAt(topicPartition, leaderLogStartOffset))
+      (_, leaderLogStartOffset) => truncateFullyAndStartAt(topicPartition, leaderLogStartOffset))
   }
 
   /**
@@ -712,8 +713,9 @@ abstract class AbstractFetcherThread(name: String,
                                                      currentLeaderEpoch: Int,
                                                      leaderLogStartOffset: Long): PartitionFetchState = {
     fetchOffsetAndApplyFun(topicPartition, currentLeaderEpoch,
-      leaderLocalLogStartOffset =>
-        buildRemoteLogAuxState(topicPartition, currentLeaderEpoch, leaderLocalLogStartOffset, leaderLogStartOffset))
+      (epochForLeaderLocalLogStartOffset, leaderLocalLogStartOffset) =>
+        buildRemoteLogAuxState(topicPartition, currentLeaderEpoch, leaderLocalLogStartOffset,
+          epochForLeaderLocalLogStartOffset, leaderLogStartOffset))
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -24,8 +24,8 @@ import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
 import org.apache.kafka.server.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteResourceNotFoundException, RemoteStorageManager}
 import org.easymock.EasyMock
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertNotNull, assertTrue}
+import org.junit.jupiter.api.{AfterEach, BeforeEach}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.easymock.EasyMock.{anyObject, expect, reset, verify}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -25,29 +25,27 @@ import kafka.cluster.BrokerEndPoint
 import kafka.log.LogAppendInfo
 import kafka.message.NoCompressionCodec
 import kafka.metrics.KafkaYammerMetrics
-import kafka.server.AbstractFetcherThread.ReplicaFetch
-import kafka.server.AbstractFetcherThread.ResultWithPartitions
+import kafka.server.AbstractFetcherThread.{ReplicaFetch, ResultWithPartitions}
+import kafka.server.{AbstractFetcherThread, BrokerTopicStats, FailedPartitions, FetcherMetrics, Fetching, InitialFetchState, LogOffsetMetadata, OffsetAndEpoch, OffsetTruncationState, PartitionFetchState, Truncating}
 import kafka.utils.Implicits.MapExtensionMethods
 import kafka.utils.TestUtils
-import org.apache.kafka.common.KafkaException
-import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{FencedLeaderEpochException, UnknownLeaderEpochException}
 import org.apache.kafka.common.message.FetchResponseData
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.EpochEndOffset
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record._
-import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.requests.FetchRequest
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test}
 
-import scala.jdk.CollectionConverters._
-import scala.collection.{Map, Set, mutable}
-import scala.util.Random
-
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.{Map, Set, mutable}
 import scala.compat.java8.OptionConverters._
+import scala.jdk.CollectionConverters._
+import scala.util.Random
 
 class AbstractFetcherThreadTest {
 
@@ -531,6 +529,7 @@ class AbstractFetcherThreadTest {
       override protected def buildRemoteLogAuxState(topicPartition: TopicPartition,
                                                     leaderEpoch: Int,
                                                     fetchOffset: Long,
+                                                    epochForLeaderLocalLogStartOffset: Int,
                                                     leaderLogStartOffset: Long): Unit = {
         isErrorHandled = true
         throw new FencedLeaderEpochException(s"Epoch $leaderEpoch is fenced")
@@ -563,7 +562,7 @@ class AbstractFetcherThreadTest {
     val partition = new TopicPartition("topic", 0)
     var fetchedEarliestOffset = false
     val fetcher = new MockFetcherThread() {
-      override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
+      override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): (Int, Long) = {
         fetchedEarliestOffset = true
         throw new FencedLeaderEpochException(s"Epoch $leaderEpoch is fenced")
       }
@@ -932,13 +931,16 @@ class AbstractFetcherThreadTest {
                          var logEndOffset: Long,
                          var highWatermark: Long,
                          var rlmEnabled: Boolean,
+                         var epochAtLocalLogStartOffset: Int,
                          var localLogStartOffset: Long)
 
     object PartitionState {
       def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long, rlmEnabled: Boolean): PartitionState = {
         val logStartOffset = log.headOption.map(_.baseOffset).getOrElse(0L)
+        val epochAndLocaLogStartOffset = log.headOption.map(_.partitionLeaderEpoch()).getOrElse(-1)
         val logEndOffset = log.lastOption.map(_.nextOffset).getOrElse(0L)
-        new PartitionState(log.toBuffer, leaderEpoch, logStartOffset, logEndOffset, highWatermark, rlmEnabled, logStartOffset)
+        new PartitionState(log.toBuffer, leaderEpoch, logStartOffset, logEndOffset, highWatermark,
+          rlmEnabled, epochAndLocaLogStartOffset, logStartOffset)
       }
 
       def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long): PartitionState = {
@@ -1250,10 +1252,10 @@ class AbstractFetcherThreadTest {
       }
     }
 
-    override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
+    override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): (Int, Long) = {
       val leaderState = leaderPartitionState(topicPartition)
       checkLeaderEpochAndThrow(leaderEpoch, leaderState)
-      leaderState.localLogStartOffset
+      (leaderState.epochAtLocalLogStartOffset, leaderState.localLogStartOffset)
     }
 
     override protected def fetchLatestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
@@ -1265,6 +1267,7 @@ class AbstractFetcherThreadTest {
     override protected def buildRemoteLogAuxState(topicPartition: TopicPartition,
                                                   currentLeaderEpoch: Int,
                                                   fetchOffset: Long,
+                                                  epochForLeaderLocalLogStartOffset: Int,
                                                   leaderLogStartOffset: Long): Unit = {
       truncateFullyAndStartAt(topicPartition, fetchOffset)
       replicaPartitionState(topicPartition).logStartOffset = leaderLogStartOffset

--- a/core/src/test/scala/unit/kafka/server/FindOffsetForEpochOnLeaderTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FindOffsetForEpochOnLeaderTest.scala
@@ -1,0 +1,172 @@
+package kafka.server
+
+import java.util.stream.Stream
+
+import kafka.cluster.BrokerEndPoint
+import kafka.server.FindOffsetForEpochOnLeaderTest.{newReplicaFetcherThread, topicPartition}
+import kafka.server.checkpoints.LeaderEpochCheckpoint
+import kafka.server.epoch.{EpochEntry, LeaderEpochFileCache}
+import kafka.utils.TestUtils
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.utils.SystemTime
+import org.easymock.EasyMock.mock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.{Arguments, MethodSource}
+
+import scala.collection.Seq
+import scala.jdk.CollectionConverters._
+
+object FindOffsetForEpochOnLeaderTest {
+  private val topicPartition = new TopicPartition("Barton", 0)
+
+  val leaderEpochCache = {
+    val leaderEpochCache = newLeaderEpochCache(10)
+    leaderEpochCache.assign(epoch = 0, startOffset = 0)
+    leaderEpochCache.assign(epoch = 2, startOffset = 5)
+    leaderEpochCache.assign(epoch = 10, startOffset = 7)
+    leaderEpochCache
+  }
+
+  def testCases(): Stream[Arguments] = {
+    Seq(
+      // Log empty on leader and follower.
+      Arguments.of(newLeaderEpochCache(0), 0, 0, 0, 0, Some(0)),
+
+      Arguments.of(leaderEpochCache,
+        0, // search offset.
+        0, // epoch for leader local start offset (1) is 0.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(0) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        1, // search offset.
+        0, // epoch for leader local start offset (2) is 0.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(0) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        2, // search offset.
+        0, // epoch for leader local start offset (3) is 0.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(0) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        3, // search offset.
+        0, // epoch for leader local start offset (4) is 0.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(0) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        4, // search offset.
+        2, // epoch for leader local start offset (5) is 2.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(0) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        5, // search offset.
+        2, // epoch for leader local start offset (6) is 2.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(2) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        6, // search offset.
+        2, // epoch for leader local start offset (7) is 3.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(2) // expected leader epoch.
+      ),
+
+      Arguments.of(leaderEpochCache,
+        7, // search offset.
+        10, // epoch for leader local start offset (8) is 10.
+        10, // current leader epoch on the leader.
+        10, // current leader epoch on the follower.
+        Some(10) // expected leader epoch.
+      ),
+
+      // Fencing
+      Arguments.of(leaderEpochCache,
+        7, // search offset.
+        3, // epoch for leader local start offset (8) is 3.
+        10, // current leader epoch on the leader.
+        11, // current leader epoch on the follower.
+        None // expected leader epoch.
+      ),
+
+      // Fencing
+      Arguments.of(leaderEpochCache,
+        7, // search offset.
+        3, // epoch for leader local start offset (8) is 3.
+        10, // current leader epoch on the leader.
+        9, // current leader epoch on the follower.
+        None // expected leader epoch.
+      )
+    ).asJava.stream()
+  }
+
+  private def newLeaderEpochCache(logEndOffset: Long): LeaderEpochFileCache = {
+    val checkpoint: LeaderEpochCheckpoint = new LeaderEpochCheckpoint {
+      private var epochs: Seq[EpochEntry] = Seq()
+      override def write(epochs: Iterable[EpochEntry]): Unit = this.epochs = epochs.toSeq
+      override def read(): Seq[EpochEntry] = this.epochs
+    }
+
+    new LeaderEpochFileCache(topicPartition, () => logEndOffset, checkpoint)
+  }
+
+  def newReplicaFetcherThread(blockingSend: BlockingSend): ReplicaFetcherThread = {
+    val props = TestUtils.createBrokerConfig(1, "localhost:1234")
+    val config = KafkaConfig.fromProps(props)
+
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+
+    new ReplicaFetcherThread(
+      name = "Piledriver",
+      fetcherId = 0,
+      sourceBroker = new BrokerEndPoint(0, "localhost", 1000),
+      brokerConfig = config,
+      failedPartitions = new FailedPartitions,
+      replicaMgr = replicaManager,
+      metrics =  new Metrics(),
+      time = new SystemTime(),
+      quota = null,
+      leaderEndpointBlockingSend = Some(blockingSend))
+  }
+
+}
+
+class FindOffsetForEpochOnLeaderTest {
+  @ParameterizedTest
+  @MethodSource(Array("testCases"))
+  def test(leaderEpochOnLeader: LeaderEpochFileCache,
+           searchOffset: Int,
+           epochForLeaderLocalLogStartOffset: Int,
+           currentLeaderEpochOnLeader: Int,
+           currentLeaderEpochInRequest: Int,
+           expectedLeaderEpoch: Option[Int]): Unit = {
+
+    val leaderEndpoint = new OffsetsForLeaderEpochServer()
+      .add(topicPartition, leaderEpochOnLeader, currentLeaderEpochOnLeader)
+
+    val replicaFetcher = newReplicaFetcherThread(leaderEndpoint)
+
+    val maybeLeaderEpoch = replicaFetcher.findEpochForOffsetOnLeader(
+       topicPartition, searchOffset, epochForLeaderLocalLogStartOffset, currentLeaderEpochInRequest)
+
+    assertEquals(expectedLeaderEpoch, maybeLeaderEpoch)
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/OffsetsForLeaderEpochServer.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetsForLeaderEpochServer.scala
@@ -1,0 +1,110 @@
+package kafka.server
+
+import kafka.server.epoch.LeaderEpochFileCache
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.{EpochEndOffset, OffsetForLeaderTopicResult, OffsetForLeaderTopicResultCollection}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET
+import org.apache.kafka.common.requests.{AbstractRequest, OffsetsForLeaderEpochRequest, OffsetsForLeaderEpochResponse}
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+/**
+  * Mock of a broker endpoint which serves only [[OffsetsForLeaderEpochRequest]] based on predefined leader
+  * epoch cache files. This mock does not involve any actual RPC.
+  *
+  * The partitions for which a leader epoch cache is defined are assumed to be online on the leader.
+  * */
+class OffsetsForLeaderEpochServer extends BlockingSend {
+  private val leaderEpochFiles: mutable.Map[TopicPartition, LeaderEpochFileCache] = mutable.Map()
+  private val currentLeaderEpochs: mutable.Map[TopicPartition, Int] = mutable.Map()
+
+  /**
+    * Add the given leader epoch cache for the topic-partition.
+    * Set the value of the current leader epoch for this partition on the leader.
+    */
+  def add(topicPartition: TopicPartition,
+          leaderEpochFileCache: LeaderEpochFileCache,
+          currentLeaderEpoch: Int): OffsetsForLeaderEpochServer = {
+
+    leaderEpochFiles.put(topicPartition, leaderEpochFileCache)
+    currentLeaderEpochs.put(topicPartition, currentLeaderEpoch)
+    this
+  }
+
+  override def sendRequest(requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): ClientResponse = {
+    val request = requestBuilder.build();
+
+    // Only serve OffsetsForLeaderEpochRequest
+    if (! (request.isInstanceOf[OffsetsForLeaderEpochRequest])) {
+      throw new UnsupportedOperationException("This mock only serves OffsetsForLeaderEpochRequest")
+    }
+
+    val offsetsForLeaderEpochRequest = request.asInstanceOf[OffsetsForLeaderEpochRequest]
+
+    val epochEndOffsetsPerTopic: mutable.Map[String, mutable.Buffer[EpochEndOffset]] = mutable.Map()
+
+    offsetsForLeaderEpochRequest.data().topics().asScala
+      .flatMap(topic => {
+        epochEndOffsetsPerTopic.put(topic.topic(), mutable.Buffer[EpochEndOffset]())
+        Seq(topic.topic()).zip(topic.partitions().asScala)
+      })
+      .foreach(_ match { case (topic, partition) => {
+        val topicPartition = new TopicPartition(topic, partition.partition())
+
+        val epochEndOffset = {
+          val currentLeaderEpoch = currentLeaderEpochs(topicPartition)
+          val leaderEpochCache = leaderEpochFiles(topicPartition)
+
+          if (currentLeaderEpoch > partition.currentLeaderEpoch()) {
+            new EpochEndOffset()
+              .setPartition(partition.partition())
+              .setErrorCode(Errors.FENCED_LEADER_EPOCH.code)
+
+          } else if (currentLeaderEpoch < partition.currentLeaderEpoch()) {
+            new EpochEndOffset()
+              .setPartition(partition.partition())
+              .setErrorCode(Errors.UNKNOWN_LEADER_EPOCH.code)
+
+          } else {
+            val (foundEpoch, foundOffset) = leaderEpochCache.endOffsetFor(partition.leaderEpoch())
+
+            val result = new EpochEndOffset()
+              .setPartition(partition.partition())
+              .setErrorCode(Errors.NONE.code)
+
+            if (foundOffset != UNDEFINED_EPOCH_OFFSET) {
+              result
+                .setLeaderEpoch(foundEpoch)
+                .setEndOffset(foundOffset)
+            }
+
+            result
+          }
+        }
+
+        epochEndOffsetsPerTopic(topic).addOne(epochEndOffset)
+      }
+    })
+
+    val result = epochEndOffsetsPerTopic.map((_: (String, mutable.Buffer[EpochEndOffset])) match {
+      case (topic, epochEndOffsets) =>
+        new OffsetForLeaderTopicResult()
+          .setTopic(topic)
+          .setPartitions(epochEndOffsets.toList.asJava)
+    })
+
+    val endOffsetsForAllTopics = new OffsetForLeaderTopicResultCollection(result.asJava.iterator())
+    val response =
+      new OffsetsForLeaderEpochResponse(new OffsetForLeaderEpochResponseData().setTopics(endOffsetsForAllTopics))
+
+    new ClientResponse(null, null, null, 0, 0, false, null, null, response)
+  }
+
+  override def initiateClose(): Unit = {}
+
+  override def close(): Unit = {}
+}


### PR DESCRIPTION
This PR includes two fixes:

1. When the follower builds the auxiliary state of a topic-partition before replication following an offset-moved-to-tiered-storage response from the leader, in the case where the leader epoch at the leader ELO (earliest local log offset) is known by the follower, the replica fetcher will try to find the rlsMetadata at that ELO instead of ELO - 1. Since by definition the ELO is never in the remote storage, the rlsMetadata requested is never found. This PR makes the follower fetch the rlsMetadata at offset ELO - 1 instead. It is guaranteed to work in the cases where the leader epoch at offset ELO -1 is known by the follower (from its leader epoch cache) and that leader epoch matches what is defined on the leader, i.e. the follower and leader agree on what leader epoch is at offset ELO - 1.

2. Currently, the method used to lookup the rlsMetadata of the log at offset ELO - 1 is to decrement the leader epoch at ELO and try to find the metadata using RLM. If the metadata is not found, the leader epoch is decremented again until the metadata is found. However, in case of unclean leader elections, it is possible that this search method resolves the wrong leader epoch and metadata (i.e. not consistent with the current leader). We found scenarios where this could put the follower in an endless cycle of never-completing truncations. This PR makes the follower retrieve the leader epoch at ELO - 1 from the leader to ensure the leader epoch used to resolve the metadata is correct.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [X] Verify documentation (including upgrade notes)
- [X] Verify test coverage and CI build status
