### PR TITLE
Clear topicId cache when removing topic partitions

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -22,7 +22,6 @@ import kafka.metrics.KafkaMetricsGroup
 import kafka.server._
 import kafka.server.checkpoints.{CheckpointWriteBuffer, LeaderEpochCheckpoint, LeaderEpochCheckpointFile}
 import kafka.server.epoch.EpochEntry
-import kafka.utils.Implicits._
 import kafka.utils.Logging
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.common._
@@ -46,7 +45,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.{lang, util}
 import scala.collection.Searching._
 import scala.collection.mutable.ListBuffer
-import scala.collection.{Seq, Set, mutable}
+import scala.collection.{Seq, Set}
+import scala.collection.concurrent
 import scala.jdk.CollectionConverters._
 import scala.jdk.OptionConverters.RichOptional
 
@@ -121,8 +121,9 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
   private val poolSize = rlmConfig.remoteLogManagerThreadPoolSize
   private val rlmScheduledThreadPool = new RLMScheduledThreadPool(poolSize)
 
-  // topic ids that are received on leadership changes, this map is NEVER cleared
-  private val topicIds: mutable.Map[String, Uuid] = mutable.Map.empty
+  // topic ids that are received on leadership changes, this map is cleared on stop partitions
+  private val topicPartitionIds: concurrent.Map[TopicPartition, Uuid] = new ConcurrentHashMap[TopicPartition, Uuid]().asScala
+
 
   @volatile private var closed = false
 
@@ -246,10 +247,23 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
       .map(p => new TopicIdPartition(topicIds.get(p.topic), p.topicPartition) -> p).toMap
     val followerPartitions = partitionsBecomeFollower.filterNot(nonSupported)
       .map(p => new TopicIdPartition(topicIds.get(p.topic), p.topicPartition))
+
+    def cacheTopicPartitionIds(topicIdPartition: TopicIdPartition): Unit = {
+      val maybePreviousTopicId = topicPartitionIds.put(topicIdPartition.topicPartition(), topicIdPartition.topicId())
+      maybePreviousTopicId.filter(_ != topicIdPartition.topicId())
+        .foreach { previousTopicId =>
+          warn(s"Previous cached topic id $previousTopicId for ${topicIdPartition.topicPartition()} does " +
+            s"not match update topic id ${topicIdPartition.topicId()}")
+        }
+    }
+
     if (leaderPartitions.nonEmpty || followerPartitions.nonEmpty) {
       debug(s"Effective topic partitions after filtering compact and internal topics, " +
         s"leaders: ${leaderPartitions.keySet} and followers: $followerPartitions")
-      topicIds.forEach((topic, uuid) => this.topicIds.put(topic, uuid))
+
+      leaderPartitions.keySet.foreach(cacheTopicPartitionIds)
+      followerPartitions.foreach(cacheTopicPartitionIds)
+
       remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions.keySet.asJava, followerPartitions.asJava)
       followerPartitions.foreach {
         topicIdPartition => doHandleLeaderOrFollowerPartitions(topicIdPartition, _.convertToFollower())
@@ -270,36 +284,34 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
    */
   def stopPartitions(allPartitions: Set[TopicPartition], delete: Boolean, errorHandler: (TopicPartition, Throwable) => Unit): Unit = {
     debug(s"Stopping ${allPartitions.size} partitions, delete: $delete")
-    val partitionsByTopic = allPartitions.groupBy(_.topic())
-    partitionsByTopic.forKeyValue((topic, partitions) => {
-      val topicId = topicIds.get(topic)
-      if (topicId.isDefined) {
-        val tpIds = partitions.map(new TopicIdPartition(topicId.get, _))
-        tpIds.foreach(tpId => {
-          val topicPartition = tpId.topicPartition()
-          try {
-            val task = leaderOrFollowerTasks.remove(tpId)
-            if (task != null) {
-              info(s"Cancelling the RLM task for tp: $topicPartition")
-              task.cancel()
-            }
-            if (delete) {
-              debug(s"Deleting the remote log segments for partition: $tpId")
-              remoteLogMetadataManager.listRemoteLogSegments(tpId).forEachRemaining(elt => deleteRemoteLogSegment(elt, _ => true))
-            }
+    val tpIds = allPartitions
+      .filter(topicPartitionIds contains)
+      .map(tp => new TopicIdPartition(topicPartitionIds(tp), tp))
+      .toSet
 
-            brokerTopicStats.tierLagStats(topicPartition.topic()).removePartition(topicPartition.partition())
-
-          } catch {
-            case ex: Throwable => errorHandler(topicPartition, ex)
-          }
-        })
-        if (delete) {
-          // NOTE: this#stopPartitions method is called when Replica state changes to Offline and ReplicaDeletionStarted
-          remoteLogMetadataManager.onStopPartitions(tpIds.asJava)
+    tpIds.foreach(tpId => {
+      val partition = tpId.topicPartition()
+      try {
+        val task = leaderOrFollowerTasks.remove(tpId)
+        if (task != null) {
+          info(s"Cancelling the RLM task for tp: $partition")
+          task.cancel()
         }
+        if (delete) {
+          info(s"Deleting the remote log segments for partition: $tpId")
+          remoteLogMetadataManager.listRemoteLogSegments(tpId).forEachRemaining(elt => deleteRemoteLogSegment(elt, _ => true))
+        }
+        brokerTopicStats.tierLagStats(partition.topic()).removePartition(partition.partition())
+      } catch {
+        case ex: Throwable => errorHandler(partition, ex)
       }
     })
+
+    if (delete) {
+      // NOTE: this#stopPartitions method is called when Replica state changes to Offline and ReplicaDeletionStarted
+      remoteLogMetadataManager.onStopPartitions(tpIds.asJava)
+      topicPartitionIds --= allPartitions
+    }
   }
 
   private def deleteRemoteLogSegment(segmentMetadata: RemoteLogSegmentMetadata, predicate: RemoteLogSegmentMetadata => Boolean): Boolean = {
@@ -772,7 +784,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
                                     epochForOffset: Int,
                                     offset: Long): Optional[RemoteLogSegmentMetadata] = {
     val topicIdPartition =
-      topicIds.get(tp.topic()) match {
+      topicPartitionIds.get(tp) match {
         case Some(uuid) => Some(new TopicIdPartition(uuid, tp))
         case None => None
       }
@@ -839,7 +851,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     //todo-tier Here also, we do not need to go through all the remote log segments to find the segments
     // containing the timestamp. We should find the  epoch for the startingOffset and then  traverse  through those
     // offsets and subsequent leader epochs to find the target timestamp/offset.
-    topicIds.get(tp.topic()) match {
+    topicPartitionIds.get(tp) match {
       case Some(uuid) =>
         val topicIdPartition = new TopicIdPartition(uuid, tp)
         remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition).asScala.foreach(rlsMetadata =>

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -27,12 +27,12 @@ import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.utils.Utils
-import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
+import org.apache.kafka.common.{KafkaException, TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
 import org.apache.kafka.server.log.remote.storage._
 import org.easymock.{CaptureType, EasyMock}
 import org.easymock.EasyMock._
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -73,6 +73,72 @@ class RemoteLogManagerTest {
     val rlmmConfig = rlmConfig.remoteLogMetadataManagerProps()
     assertEquals(props.get(rlmmConfigPrefix + key), rlmmConfig.get(key))
     assertFalse(rlmmConfig.containsKey("remote.log.metadata.y"))
+  }
+
+  @Test
+  def testTopicIdCacheUpdates(): Unit = {
+    val leaderTopicIdPartition =  new TopicIdPartition(Uuid.randomUuid(),
+      new TopicPartition("Leader", 0))
+    val followerTopicIdPartition = new TopicIdPartition(Uuid.randomUuid(),
+      new TopicPartition("Follower", 0))
+    val topicIds: util.Map[String, Uuid] = Map(
+      leaderTopicIdPartition.topicPartition().topic() -> leaderTopicIdPartition.topicId(),
+      followerTopicIdPartition.topicPartition().topic() -> followerTopicIdPartition.topicId()
+    ).asJava
+
+    def mockPartition(topicIdPartition: TopicIdPartition) = {
+      val tp = topicIdPartition.topicPartition()
+
+      val partition: Partition = niceMock(classOf[Partition])
+      expect(partition.topicPartition).andReturn(tp).anyTimes()
+      expect(partition.topic).andReturn(tp.topic()).anyTimes()
+      expect(partition.log).andReturn(None).anyTimes()
+
+      partition
+    }
+
+    val mockLeaderPartition = mockPartition(leaderTopicIdPartition)
+    val mockFollowerPartition = mockPartition(followerTopicIdPartition)
+
+    val rlmm: RemoteLogMetadataManager = createNiceMock(classOf[RemoteLogMetadataManager])
+    expect(rlmm.listRemoteLogSegments(anyObject()))
+      .andAnswer(() => Iterator[RemoteLogSegmentMetadata]().asJava).anyTimes()
+
+    replay(rlmm, mockLeaderPartition, mockFollowerPartition)
+
+    val remoteLogManager = new RemoteLogManager(_ => None,
+      (_, _) => {}, rlmConfig, time, 1, clusterId, logsDir, brokerTopicStats) {
+      override private[remote] def createRemoteLogMetadataManager(): RemoteLogMetadataManager = rlmm
+    }
+
+    // We use the internal implementation details of fetchRemoteLogSegmentMetadata to check that the topic is
+    // in the cache
+    def verifyInCache(topicIdPartitions: TopicIdPartition*): Unit = {
+      topicIdPartitions.foreach(topicIdPartition => {
+        assertDoesNotThrow(() => remoteLogManager.fetchRemoteLogSegmentMetadata(topicIdPartition.topicPartition(), 0, 0))
+      })
+    }
+
+    def verifyNotInCache(topicIdPartitions: TopicIdPartition*): Unit = {
+      topicIdPartitions.foreach(topicIdPartition => {
+        assertThrows(classOf[KafkaException],
+          () => remoteLogManager.fetchRemoteLogSegmentMetadata(topicIdPartition.topicPartition(), 0, 0))
+      })
+    }
+
+    verifyNotInCache(followerTopicIdPartition, leaderTopicIdPartition)
+    // Load cache
+    remoteLogManager.onLeadershipChange(Set(mockLeaderPartition), Set(mockFollowerPartition), topicIds)
+    verifyInCache(followerTopicIdPartition, leaderTopicIdPartition)
+
+    // Evict from cache
+    remoteLogManager.stopPartitions(Set(leaderTopicIdPartition.topicPartition()), delete = true, (_, _) => {})
+    verifyNotInCache(leaderTopicIdPartition)
+    verifyInCache(followerTopicIdPartition)
+
+    // Evict from cache
+    remoteLogManager.stopPartitions(Set(followerTopicIdPartition.topicPartition()), delete = true, (_, _) => {})
+    verifyNotInCache(leaderTopicIdPartition, followerTopicIdPartition)
   }
 
   @Test


### PR DESCRIPTION
Resolves https://github.com/satishd/kafka/issues/22

## Problem
Topic IDs are added to `RemoteLogManager.scala` but never cleaned up when a topic is deleted. This may cause a memory leak.

## Change
This change clears topicId cache when removing topic partitions.

## Testing
1. Added a unit test to validate that the topics are indeed removed from the cache.
2. `./gradlew unitTest` is successful.