### PR TITLE
Fix incorrect topic Id generated due to race condition

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -123,7 +123,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
 
   // topic ids that are received on leadership changes, this map is cleared on stop partitions
   private val topicPartitionIds: concurrent.Map[TopicPartition, Uuid] = new ConcurrentHashMap[TopicPartition, Uuid]().asScala
-
+  private val onLeadershipChangeLock = new Object
 
   @volatile private var closed = false
 
@@ -236,17 +236,14 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
                          topicIds: util.Map[String, Uuid]): Unit = {
     trace(s"Received leadership changes for partitionsBecomeLeader: $partitionsBecomeLeader " +
       s"and partitionsBecomeLeader: $partitionsBecomeLeader")
+
     // Compact topics and internal topics are filtered here as they are not supported with tiered storage.
     def nonSupported(partition: Partition): Boolean = {
       Topic.isInternal(partition.topic) ||
-        partition.log.exists(log => log.config.compact || !log.config.remoteStorageEnable) ||
+        // fetchLog should reflect up to date configuration
+        fetchLog(partition.topicPartition).exists(log => log.config.compact || !log.config.remoteStorageEnable) ||
         partition.topicPartition.topic().equals(TopicBasedRemoteLogMetadataManagerConfig.REMOTE_LOG_METADATA_TOPIC_NAME)
     }
-
-    val leaderPartitions = partitionsBecomeLeader.filterNot(nonSupported)
-      .map(p => new TopicIdPartition(topicIds.get(p.topic), p.topicPartition) -> p).toMap
-    val followerPartitions = partitionsBecomeFollower.filterNot(nonSupported)
-      .map(p => new TopicIdPartition(topicIds.get(p.topic), p.topicPartition))
 
     def cacheTopicPartitionIds(topicIdPartition: TopicIdPartition): Unit = {
       val maybePreviousTopicId = topicPartitionIds.put(topicIdPartition.topicPartition(), topicIdPartition.topicId())
@@ -257,20 +254,36 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         }
     }
 
-    if (leaderPartitions.nonEmpty || followerPartitions.nonEmpty) {
-      debug(s"Effective topic partitions after filtering compact and internal topics, " +
-        s"leaders: ${leaderPartitions.keySet} and followers: $followerPartitions")
+    /**
+     * The following scenarios are possible when the onLeadershipChange method is invoked:
+     *
+     * 1. LeaderAndIsrRequest arrives before ConfigHandler config change for remoteStorageEnable: In this case, there will be a separate call for config change.
+     * 2. LeaderAndIsrRequest arrives after ConfigHandler config for remoteStorageEnable: In this case, the config changes will not be lost as there is a fetchLog call now to fetch the log updates.
+     * 3. LeaderAndIsrRequest arrives at same time as ConfigHandler config for remoteStorageEnable: Falls in to 1 or 2 above depending on sequencing
+     *
+     * This method is safe for all the three scenarios and will be able to pick up the updated configuration.
+     */
+    onLeadershipChangeLock synchronized {
+      val leaderPartitions = partitionsBecomeLeader.filterNot(nonSupported)
+        .map(p => new TopicIdPartition(topicIds.get(p.topic), p.topicPartition) -> p).toMap
+      val followerPartitions = partitionsBecomeFollower.filterNot(nonSupported)
+        .map(p => new TopicIdPartition(topicIds.get(p.topic), p.topicPartition))
 
-      leaderPartitions.keySet.foreach(cacheTopicPartitionIds)
-      followerPartitions.foreach(cacheTopicPartitionIds)
+      if (leaderPartitions.nonEmpty || followerPartitions.nonEmpty) {
+        debug(s"Effective topic partitions after filtering compact and internal topics, " +
+          s"leaders: ${leaderPartitions.keySet} and followers: $followerPartitions")
 
-      remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions.keySet.asJava, followerPartitions.asJava)
-      followerPartitions.foreach {
-        topicIdPartition => doHandleLeaderOrFollowerPartitions(topicIdPartition, _.convertToFollower())
-      }
-      leaderPartitions.foreach {
-        case (topicIdPartition, partition) =>
-          doHandleLeaderOrFollowerPartitions(topicIdPartition, _.convertToLeader(partition.getLeaderEpoch))
+        leaderPartitions.keySet.foreach(cacheTopicPartitionIds)
+        followerPartitions.foreach(cacheTopicPartitionIds)
+
+        remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions.keySet.asJava, followerPartitions.asJava)
+        followerPartitions.foreach {
+          topicIdPartition => doHandleLeaderOrFollowerPartitions(topicIdPartition, _.convertToFollower())
+        }
+        leaderPartitions.foreach {
+          case (topicIdPartition, partition) =>
+            doHandleLeaderOrFollowerPartitions(topicIdPartition, _.convertToLeader(partition.getLeaderEpoch))
+        }
       }
     }
   }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -80,15 +80,13 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
                                                         wasRemoteLogEnabledBeforeUpdate: Boolean): Unit = {
 
     def maybeFetchTopicId(topic: String, logs: Seq[Log]): Map[String, Uuid] = {
-      val topicId = Map(topic -> logs.head.topicId)
+      val topicId = replicaManager.zkClient.getOrElse(throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
+        logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration as ZkClient is missing"))
+        .getTopicIdsForTopics(Predef.Set(topic))
         .filter(entry => entry._2 != Uuid.ZERO_UUID)
-        .getOrElse(topic,
-          replicaManager.zkClient.map(_.getTopicIdsForTopics(Predef.Set(topic))
-            .filter(entry => entry._2 != Uuid.ZERO_UUID)
-            .getOrElse(topic, throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
-              logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration due to unavailability of topic ids for $topic")))
-            .getOrElse(throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
-              logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration as ZkClient is missing")))
+        .getOrElse(topic, throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
+          logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration due to unavailability of topic ids for $topic"))
+
       Map(topic -> topicId)
     }
 

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -74,15 +74,27 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
       // In Kafka v2.8, there is a bug when reading the topicId from the Log. The first LeaderAndIsr notification
       // doesn't set the topic-id in the Log which results to Uuid.ZERO_UUID. This has been fixed in the trunk.
       // So, loading the topic-id from ZK directly.
-      replicaManager.zkClient.map(_.getTopicIdsForTopics(Predef.Set(topic))).foreach { topicIds =>
-        maybeBootstrapRemoteLogComponents(topicIds, logs, wasRemoteLogEnabledBeforeUpdate)
-      }
+      val topicIds = maybeFetchTopicId(topic)
+      maybeBootstrapRemoteLogComponents(topicIds, logs, wasRemoteLogEnabledBeforeUpdate)
     }
+  }
+
+  private def maybeFetchTopicId(topic: String): Map[String, Uuid] = {
+    val topicId = Map(topic -> logs.head.topicId)
+      .filter(entry => entry._2 != Uuid.ZERO_UUID)
+      .getOrElse(topic,
+        replicaManager.zkClient.map(_.getTopicIdsForTopics(Predef.Set(topic))
+          .filter(entry => entry._2 != Uuid.ZERO_UUID))
+          .getOrElse(topic, throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
+            logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration due to unavailability of topic ids for topic."))
+          )
+    Map(topic -> topicId)
   }
 
   private[server] def maybeBootstrapRemoteLogComponents(topicIds: Map[String, Uuid],
                                                         logs: Seq[Log],
                                                         wasRemoteLogEnabledBeforeUpdate: Boolean): Unit = {
+
     val isRemoteLogEnabled = logs.head.remoteLogEnabled()
     // Topic configs gets updated incrementally. This check is added to prevent redundant updates.
     if (!wasRemoteLogEnabledBeforeUpdate && isRemoteLogEnabled) {

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -56,7 +56,7 @@ trait ConfigHandler {
 class TopicConfigHandler(private val replicaManager: ReplicaManager,
                          kafkaConfig: KafkaConfig, val quotas: QuotaManagers, kafkaController: KafkaController) extends ConfigHandler with Logging  {
 
-  private[server] def updateLogConfig(topic: String,
+  private def updateLogConfig(topic: String,
                               topicConfig: Properties,
                               configNamesToExclude: Set[String]): Unit = {
     val logManager = replicaManager.logManager

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -56,7 +56,7 @@ trait ConfigHandler {
 class TopicConfigHandler(private val replicaManager: ReplicaManager,
                          kafkaConfig: KafkaConfig, val quotas: QuotaManagers, kafkaController: KafkaController) extends ConfigHandler with Logging  {
 
-  private def updateLogConfig(topic: String,
+  private[server] def updateLogConfig(topic: String,
                               topicConfig: Properties,
                               configNamesToExclude: Set[String]): Unit = {
     val logManager = replicaManager.logManager
@@ -71,29 +71,31 @@ class TopicConfigHandler(private val replicaManager: ReplicaManager,
       val logConfig = LogConfig.fromProps(logManager.currentDefaultConfig.originals, props)
       val wasRemoteLogEnabledBeforeUpdate = logs.head.remoteLogEnabled()
       logs.foreach(_.updateConfig(logConfig))
-      // In Kafka v2.8, there is a bug when reading the topicId from the Log. The first LeaderAndIsr notification
-      // doesn't set the topic-id in the Log which results to Uuid.ZERO_UUID. This has been fixed in the trunk.
-      // So, loading the topic-id from ZK directly.
-      val topicIds = maybeFetchTopicId(topic)
-      maybeBootstrapRemoteLogComponents(topicIds, logs, wasRemoteLogEnabledBeforeUpdate)
+      maybeBootstrapRemoteLogComponents(topic, logs, wasRemoteLogEnabledBeforeUpdate)
     }
   }
 
-  private def maybeFetchTopicId(topic: String): Map[String, Uuid] = {
-    val topicId = Map(topic -> logs.head.topicId)
-      .filter(entry => entry._2 != Uuid.ZERO_UUID)
-      .getOrElse(topic,
-        replicaManager.zkClient.map(_.getTopicIdsForTopics(Predef.Set(topic))
-          .filter(entry => entry._2 != Uuid.ZERO_UUID))
-          .getOrElse(topic, throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
-            logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration due to unavailability of topic ids for topic."))
-          )
-    Map(topic -> topicId)
-  }
-
-  private[server] def maybeBootstrapRemoteLogComponents(topicIds: Map[String, Uuid],
+  private[server] def maybeBootstrapRemoteLogComponents(topic: String,
                                                         logs: Seq[Log],
                                                         wasRemoteLogEnabledBeforeUpdate: Boolean): Unit = {
+
+    def maybeFetchTopicId(topic: String, logs: Seq[Log]): Map[String, Uuid] = {
+      val topicId = Map(topic -> logs.head.topicId)
+        .filter(entry => entry._2 != Uuid.ZERO_UUID)
+        .getOrElse(topic,
+          replicaManager.zkClient.map(_.getTopicIdsForTopics(Predef.Set(topic))
+            .filter(entry => entry._2 != Uuid.ZERO_UUID)
+            .getOrElse(topic, throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
+              logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration due to unavailability of topic ids for $topic")))
+            .getOrElse(throw new ConfigException(LogConfig.RemoteLogStorageEnableProp,
+              logs.head.remoteLogEnabled(), s"Error occurred while setting the configuration as ZkClient is missing")))
+      Map(topic -> topicId)
+    }
+
+    // In Kafka v2.8, there is a bug when reading the topicId from the Log. The first LeaderAndIsr notification
+    // doesn't set the topic-id in the Log which results to Uuid.ZERO_UUID. This has been fixed in the trunk.
+    // So, loading the topic-id from ZK directly.
+    val topicIds = maybeFetchTopicId(topic, logs)
 
     val isRemoteLogEnabled = logs.head.remoteLogEnabled()
     // Topic configs gets updated incrementally. This check is added to prevent redundant updates.

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -28,11 +28,11 @@ import kafka.log.LogConfig._
 import kafka.log.remote.RemoteLogManager
 import kafka.utils._
 import kafka.server.Constants._
-import kafka.zk.ConfigEntityChangeNotificationZNode
+import kafka.zk.{ConfigEntityChangeNotificationZNode, KafkaZkClient}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{Admin, AlterConfigOp, ConfigEntry}
 import org.apache.kafka.common.{TopicPartition, Uuid}
-import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.config.internals.QuotaConfigs
 import org.apache.kafka.common.errors.{InvalidRequestException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.metrics.Quota
@@ -435,6 +435,60 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     assertTrue(followerPartitionsArg.getValue.isEmpty)
     assertEquals(Set(partition), leaderPartitionsArg.getValue)
     verify(partition, rlm, replicaManager, log)
+  }
+
+  @Test
+  def testEnableRemoteLogStorageOnTopicWhenLogReturnsZeroUUIDTopic(): Unit = {
+    val topic = "test-topic"
+    val tp = new TopicPartition(topic, 0)
+    val partition: Partition = mock(classOf[Partition])
+    expect(partition.isLeader).andReturn(true).once()
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val leaderPartitionsArg = newCapture[Set[Partition]]()
+    val followerPartitionsArg = newCapture[Set[Partition]]()
+    expect(rlm.onLeadershipChange(capture(leaderPartitionsArg), capture(followerPartitionsArg), anyObject())).once()
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    expect(replicaManager.remoteLogManager).andReturn(Some(rlm)).once()
+    expect(replicaManager.onlinePartition(tp)).andReturn(Some(partition)).once()
+    val log: Log = mock(classOf[Log])
+    expect(log.remoteLogEnabled()).andReturn(true).once()
+    expect(log.topicId).andReturn(Uuid.ZERO_UUID).once()
+    expect(log.topicPartition).andReturn(tp).once()
+    val zkClient: KafkaZkClient  = mock(classOf[KafkaZkClient])
+    expect(zkClient.getTopicIdsForTopics(EasyMock.anyObject())).andReturn(Map(topic -> Uuid.randomUuid())).once()
+    replay(partition, rlm, replicaManager, log, zkClient)
+
+    val wasRemoteLogEnabledBeforeUpdate = false
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, null)
+    configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> Uuid.randomUuid()), Seq(log), wasRemoteLogEnabledBeforeUpdate)
+    assertTrue(followerPartitionsArg.getValue.isEmpty)
+    assertEquals(Set(partition), leaderPartitionsArg.getValue)
+    verify(partition, rlm, replicaManager, log)
+  }
+
+  @Test
+  def testEnableRemoteLogStorageOnTopicWhenLogAndZkReturnsZeroUUIDTopic(): Unit = {
+    val topic = "test-topic"
+    val tp = new TopicPartition(topic, 0)
+    val partition: Partition = mock(classOf[Partition])
+    expect(partition.isLeader).andReturn(true).once()
+    val rlm: RemoteLogManager = mock(classOf[RemoteLogManager])
+    val leaderPartitionsArg = newCapture[Set[Partition]]()
+    val followerPartitionsArg = newCapture[Set[Partition]]()
+    expect(rlm.onLeadershipChange(capture(leaderPartitionsArg), capture(followerPartitionsArg), anyObject())).once()
+    val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
+    expect(replicaManager.remoteLogManager).andReturn(Some(rlm)).once()
+    expect(replicaManager.onlinePartition(tp)).andReturn(Some(partition)).once()
+    val log: Log = mock(classOf[Log])
+    expect(log.remoteLogEnabled()).andReturn(true).times(2)
+    expect(log.topicId).andReturn(Uuid.ZERO_UUID).once()
+    val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
+    expect(zkClient.getTopicIdsForTopics(EasyMock.anyObject())).andReturn(Map(topic -> Uuid.ZERO_UUID)).once()
+    replay(partition, rlm, replicaManager, log, zkClient)
+
+    val wasRemoteLogEnabledBeforeUpdate = false
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, null)
+    assertThrows(classOf[ConfigException], () => configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> Uuid.randomUuid()), Seq(log), wasRemoteLogEnabledBeforeUpdate))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -414,7 +414,6 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
   @Test
   def testEnableRemoteLogStorageOnTopic(): Unit = {
     val topic = "test-topic"
-    val topicId = Uuid.randomUuid()
     val tp = new TopicPartition(topic, 0)
     val partition: Partition = mock(classOf[Partition])
     expect(partition.isLeader).andReturn(true).once()
@@ -428,10 +427,11 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val log: Log = mock(classOf[Log])
     expect(log.remoteLogEnabled()).andReturn(true).once()
     expect(log.topicPartition).andReturn(tp).once()
+    expect(log.topicId).andReturn(Uuid.randomUuid()).once()
     replay(partition, rlm, replicaManager, log)
     val isRemoteLogEnabledBeforeUpdate = false
     val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, null)
-    configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> topicId), Seq(log), isRemoteLogEnabledBeforeUpdate)
+    configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log), isRemoteLogEnabledBeforeUpdate)
     assertTrue(followerPartitionsArg.getValue.isEmpty)
     assertEquals(Set(partition), leaderPartitionsArg.getValue)
     verify(partition, rlm, replicaManager, log)
@@ -447,20 +447,21 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val leaderPartitionsArg = newCapture[Set[Partition]]()
     val followerPartitionsArg = newCapture[Set[Partition]]()
     expect(rlm.onLeadershipChange(capture(leaderPartitionsArg), capture(followerPartitionsArg), anyObject())).once()
+    val zkClient: KafkaZkClient  = mock(classOf[KafkaZkClient])
+    expect(zkClient.getTopicIdsForTopics(EasyMock.anyObject())).andReturn(Map(topic -> Uuid.randomUuid())).once()
     val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
     expect(replicaManager.remoteLogManager).andReturn(Some(rlm)).once()
     expect(replicaManager.onlinePartition(tp)).andReturn(Some(partition)).once()
+    expect(replicaManager.zkClient).andReturn(Some(zkClient)).once()
     val log: Log = mock(classOf[Log])
     expect(log.remoteLogEnabled()).andReturn(true).once()
     expect(log.topicId).andReturn(Uuid.ZERO_UUID).once()
     expect(log.topicPartition).andReturn(tp).once()
-    val zkClient: KafkaZkClient  = mock(classOf[KafkaZkClient])
-    expect(zkClient.getTopicIdsForTopics(EasyMock.anyObject())).andReturn(Map(topic -> Uuid.randomUuid())).once()
     replay(partition, rlm, replicaManager, log, zkClient)
 
     val wasRemoteLogEnabledBeforeUpdate = false
     val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, null)
-    configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> Uuid.randomUuid()), Seq(log), wasRemoteLogEnabledBeforeUpdate)
+    configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log), wasRemoteLogEnabledBeforeUpdate)
     assertTrue(followerPartitionsArg.getValue.isEmpty)
     assertEquals(Set(partition), leaderPartitionsArg.getValue)
     verify(partition, rlm, replicaManager, log)
@@ -476,25 +477,25 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val leaderPartitionsArg = newCapture[Set[Partition]]()
     val followerPartitionsArg = newCapture[Set[Partition]]()
     expect(rlm.onLeadershipChange(capture(leaderPartitionsArg), capture(followerPartitionsArg), anyObject())).once()
+    val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
+    expect(zkClient.getTopicIdsForTopics(EasyMock.anyObject())).andReturn(Map(topic -> Uuid.ZERO_UUID)).once()
     val replicaManager: ReplicaManager = mock(classOf[ReplicaManager])
     expect(replicaManager.remoteLogManager).andReturn(Some(rlm)).once()
     expect(replicaManager.onlinePartition(tp)).andReturn(Some(partition)).once()
+    expect(replicaManager.zkClient).andReturn(Some(zkClient)).once()
     val log: Log = mock(classOf[Log])
     expect(log.remoteLogEnabled()).andReturn(true).times(2)
     expect(log.topicId).andReturn(Uuid.ZERO_UUID).once()
-    val zkClient: KafkaZkClient = mock(classOf[KafkaZkClient])
-    expect(zkClient.getTopicIdsForTopics(EasyMock.anyObject())).andReturn(Map(topic -> Uuid.ZERO_UUID)).once()
     replay(partition, rlm, replicaManager, log, zkClient)
 
     val wasRemoteLogEnabledBeforeUpdate = false
     val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, null)
-    assertThrows(classOf[ConfigException], () => configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> Uuid.randomUuid()), Seq(log), wasRemoteLogEnabledBeforeUpdate))
+    assertThrows(classOf[ConfigException], () => configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log), wasRemoteLogEnabledBeforeUpdate))
   }
 
   @Test
   def testDisableRemoteLogStorageOnTopic(): Unit = {
     val topic = "test-topic"
-    val topicId = Uuid.randomUuid()
     val tp = new TopicPartition(topic, 0)
     val partition: Partition = mock(classOf[Partition])
     expect(partition.isLeader).andReturn(true).once()
@@ -509,11 +510,12 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     expect(log.remoteLogEnabled()).andReturn(false).times(2)
     expect(log.maybeIncrementLogStartOffsetAsRemoteLogStorageDisabled()).andReturn(true).times(2)
     expect(log.topicPartition).andReturn(tp).times(2)
+    expect(log.topicId).andReturn(Uuid.randomUuid()).times(2)
     replay(partition, rlm, replicaManager, log)
     val isRemoteLogEnabledBeforeUpdate = true
     val configHandler: TopicConfigHandler = new TopicConfigHandler(replicaManager, null, null, null)
-    configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> topicId), Seq(log), isRemoteLogEnabledBeforeUpdate)
-    configHandler.maybeBootstrapRemoteLogComponents(Map(topic -> topicId), Seq(log), isRemoteLogEnabledBeforeUpdate)
+    configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log), isRemoteLogEnabledBeforeUpdate)
+    configHandler.maybeBootstrapRemoteLogComponents(topic, Seq(log), isRemoteLogEnabledBeforeUpdate)
     verify(partition, rlm, replicaManager, log)
   }
 


### PR DESCRIPTION
Resolves https://github.com/satishd/kafka/issues/28

## Problem
When we enable tiered storage at a topic level which was created with a disabled mode, ConfigHandler attempts to invoke onLeadershipChange and here the topic ids are not present (yet).

```
replicaManager.remoteLogManager.foreach(rlm =>
        rlm.onLeadershipChange(leaderPartitions.toSet, followerPartitions.toSet, topicIds))
```

As a result, topicid defaults to something like the following:
```
[testng] [2022-03-14 23:26:16,885] WARN Previous cached topic id 4tN_eJuTTrSE3KMT8m2aKA for PhilCollins-0 does not match update topic id AAAAAAAAAAAAAAAAAAAAAA (kafka.log.remote.RemoteLogManager)
AAAAAAAAAAAAAAAAAAAAAA-0-0 --> 4tN_eJuTTrSE3KMT8m2aKA-0-0
```

This problem happens because the ConfigHandler relies on Log.scala -> Partition metadata file to be initialized with topic ids via LeaderAndISRRequest but in reality this is not the case. The Partition metadata file which stores the topic ids in all brokers are empty when this lookup is made.

The topicids are populated by the controller via LeaderAndISRRequest and this arrives after the ConfigHandler call to rlm.onLeadershipChange:
https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers#KIP516:TopicIdentifiers-PartitionMetadatafile

## Changes
1. Remove ConfigHandler's dependency on Log.PartitionMetadata to fetch the instead fetch it from Zk.
2. Synchronise RemoteLogManager.onLeadershipChange

## Testing
Added unit tests



