### PR TITLE
Use a more efficient way to obtain leader epoch in RemoteLogManager#read

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -48,6 +48,7 @@ import scala.collection.Searching._
 import scala.collection.mutable.ListBuffer
 import scala.collection.{Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
 
 class RLMScheduledThreadPool(poolSize: Int) extends Logging {
 
@@ -636,23 +637,17 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     val maxBytes = Math.min(fetchMaxBytes, fetchInfo.maxBytes)
 
     val epoch = fetchLog(tp).flatMap(log => log.leaderEpochCache.flatMap(cache => cache.epochForOffset(offset)))
-    val rlsMetadata = if (epoch.isDefined) {
-      fetchRemoteLogSegmentMetadata(tp, epoch.get, offset)
-    } else {
-      Optional.empty()
-    }
-
-    if (!rlsMetadata.isPresent) {
-      val epochStr = if (epoch.isDefined) epoch.get.toString else "NOT AVAILABLE"
+    val rlsMetadata = epoch.flatMap(epoch => fetchRemoteLogSegmentMetadata(tp, epoch, offset).toScala).getOrElse(
       throw new OffsetOutOfRangeException(
-        s"Received request for offset $offset for leader epoch $epochStr and partition $tp which does not exist in remote tier. Try again later.")
-    }
+        s"Received request for offset $offset for leader epoch ${epoch.map(_.toString).getOrElse("NOT AVAILABLE")} " +
+          s"and partition $tp which does not exist in remote tier. Try again later.")
+    )
 
-    val startPos = lookupPositionForOffset(rlsMetadata.get(), offset)
+    val startPos = lookupPositionForOffset(rlsMetadata, offset)
     var remoteSegInputStream: InputStream = null
     try {
       // Search forward for the position of the last offset that is greater than or equal to the target offset
-      remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(rlsMetadata.get(), startPos)
+      remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(rlsMetadata, startPos)
       val remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream)
 
       val firstBatch = findFirstBatch(remoteLogInputStream, offset)
@@ -680,7 +675,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
 
       var fetchDataInfo = FetchDataInfo(LogOffsetMetadata(offset), MemoryRecords.readableRecords(buffer))
       if (includeAbortedTxns) {
-        fetchDataInfo = addAbortedTransactions(firstBatch.baseOffset(), rlsMetadata.get(), fetchDataInfo)
+        fetchDataInfo = addAbortedTransactions(firstBatch.baseOffset(), rlsMetadata, fetchDataInfo)
       }
       fetchDataInfo
     } finally {
@@ -761,7 +756,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     val topicPartition = segmentMetadata.topicIdPartition().topicPartition()
     val nextSegmentBaseOffset = segmentMetadata.endOffset()+1
     var epoch = Option(segmentMetadata.segmentLeaderEpochs().lastEntry().getKey.toInt)
-    var result: Option[RemoteLogSegmentMetadata] = Option.empty;
+    var result: Option[RemoteLogSegmentMetadata] = Option.empty
     fetchLog(topicPartition).foreach ( log => {
       log.leaderEpochCache.foreach( cache => {
         while (result.isEmpty && epoch.isDefined) {

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -621,6 +621,10 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     indexCache.lookupOffset(remoteLogSegmentMetadata, offset)
   }
 
+  /*
+   WARNING: Not all code-paths through the below function have been covered by unit tests.
+   Ensure that if you modify something you add tests!
+   */
   def read(remoteStorageFetchInfo: RemoteStorageFetchInfo): FetchDataInfo = {
     val fetchMaxBytes  = remoteStorageFetchInfo.fetchMaxBytes
     val tp = remoteStorageFetchInfo.topicPartition
@@ -631,23 +635,17 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     val offset = fetchInfo.fetchOffset
     val maxBytes = Math.min(fetchMaxBytes, fetchInfo.maxBytes)
 
-    // get the epoch for the requested  offset from local leader epoch cache
-    // FIXME(@kamal), use the epochForOffset API instead of latest epoch.
-    //  val epoch = fetchLog(tp).map(log => log.leaderEpochCache.map(cache => cache.epochForOffset()))
-    var rlsMetadata: Optional[RemoteLogSegmentMetadata] = Optional.empty()
-    fetchLog(tp).foreach { log =>
-      log.leaderEpochCache.foreach(cache => {
-        var epoch = cache.latestEpoch
-        while (!rlsMetadata.isPresent && epoch.isDefined) {
-          rlsMetadata = fetchRemoteLogSegmentMetadata(tp, epoch.get, offset)
-          epoch = cache.findPreviousEpoch(epoch.get)
-        }
-      })
+    val epoch = fetchLog(tp).flatMap(log => log.leaderEpochCache.flatMap(cache => cache.epochForOffset(offset)))
+    val rlsMetadata = if (epoch.isDefined) {
+      fetchRemoteLogSegmentMetadata(tp, epoch.get, offset)
+    } else {
+      Optional.empty()
     }
 
     if (!rlsMetadata.isPresent) {
+      val epochStr = if (epoch.isDefined) epoch.get.toString else "NOT AVAILABLE"
       throw new OffsetOutOfRangeException(
-        s"Received request for offset $offset for partition $tp which does not exist in remote tier. Try again later.")
+        s"Received request for offset $offset for leader epoch $epochStr and partition $tp which does not exist in remote tier. Try again later.")
     }
 
     val startPos = lookupPositionForOffset(rlsMetadata.get(), offset)
@@ -657,24 +655,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
       remoteSegInputStream = remoteLogStorageManager.fetchLogSegment(rlsMetadata.get(), startPos)
       val remoteLogInputStream = new RemoteLogInputStream(remoteSegInputStream)
 
-      def findFirstBatch(): RecordBatch = {
-        var nextBatch: RecordBatch = null
-
-        def iterateNextBatch(): RecordBatch = {
-          nextBatch = remoteLogInputStream.nextBatch()
-          nextBatch
-        }
-        // Look for the batch which has the desired offset
-        // we will always have a batch in that segment as it is a non-compacted topic. For compacted topics, we may need
-        //to read from the subsequent segments if there is no batch available for the desired offset in the current
-        //segment. That means, desired offset is more than last offset of the current segment and immediate available
-        //offset exists in the next segment which can be higher than the desired offset.
-        while (iterateNextBatch() != null && nextBatch.lastOffset < offset) {
-        }
-        nextBatch
-      }
-
-      val firstBatch = findFirstBatch()
+      val firstBatch = findFirstBatch(remoteLogInputStream, offset)
 
       if (firstBatch == null)
         return FetchDataInfo(LogOffsetMetadata(offset), MemoryRecords.EMPTY,
@@ -705,6 +686,23 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     } finally {
       Utils.closeQuietly(remoteSegInputStream, "RemoteLogSegmentInputStream")
     }
+  }
+
+  private[remote] def findFirstBatch(remoteLogInputStream: RemoteLogInputStream, offset: Long): RecordBatch = {
+    var nextBatch: RecordBatch = null
+
+    def iterateNextBatch(): RecordBatch = {
+      nextBatch = remoteLogInputStream.nextBatch()
+      nextBatch
+    }
+    // Look for the batch which has the desired offset
+    // we will always have a batch in that segment as it is a non-compacted topic. For compacted topics, we may need
+    //to read from the subsequent segments if there is no batch available for the desired offset in the current
+    //segment. That means, desired offset is more than last offset of the current segment and immediate available
+    //offset exists in the next segment which can be higher than the desired offset.
+    while (iterateNextBatch() != null && nextBatch.lastOffset < offset) {
+    }
+    nextBatch
   }
 
   private[remote] def addAbortedTransactions(startOffset: Long,

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -23,14 +23,16 @@ import kafka.server.checkpoints.{LeaderEpochCheckpoint, LeaderEpochCheckpointFil
 import kafka.server.epoch.{EpochEntry, LeaderEpochFileCache}
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.config.AbstractConfig
+import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.record._
+import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.{TopicIdPartition, TopicPartition, Uuid}
 import org.apache.kafka.server.log.remote.storage.RemoteStorageManager.IndexType
 import org.apache.kafka.server.log.remote.storage._
 import org.easymock.{CaptureType, EasyMock}
 import org.easymock.EasyMock._
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -763,6 +765,93 @@ class RemoteLogManagerTest {
 
     val lag = brokerTopicStats.tierLagStats(topicIdPartition.topicPartition().topic()).lag()
     assertEquals(10L, lag)
+  }
+
+  @Test
+  def testReadThrowsWhenWeCannotFindEpochAssociatedWithOffset(): Unit = {
+    val partitionData = new PartitionData(0, 0, 0, Optional.empty())
+
+    val fetchInfo: RemoteStorageFetchInfo = createMock(classOf[RemoteStorageFetchInfo])
+    expect(fetchInfo.fetchMaxBytes).andReturn(0).anyTimes()
+    expect(fetchInfo.topicPartition).andReturn(topicPartition)
+    expect(fetchInfo.fetchInfo).andReturn(partitionData)
+    expect(fetchInfo.fetchIsolation).andReturn(FetchTxnCommitted)
+
+    replay(fetchInfo)
+
+    val remoteLogManager = new RemoteLogManager(_ => Option.empty, (_, _) => {}, rlmConfig, time, brokerId = 1,
+      clusterId, logsDir, brokerTopicStats)
+
+    assertThrows(classOf[OffsetOutOfRangeException], () => remoteLogManager.read(fetchInfo))
+  }
+
+  @Test
+  def testReadThrowsWhenWeCanFindEpochAssociatedWithOffsetRemoteMetadata(): Unit = {
+    val cache: LeaderEpochFileCache = createMock(classOf[LeaderEpochFileCache])
+    expect(cache.epochForOffset(anyLong())).andReturn(Option.empty)
+
+    val log: Log = createMock(classOf[Log])
+    expect(log.leaderEpochCache).andReturn(Option(cache))
+
+    val partitionData = new PartitionData(0, 0, 0, Optional.empty())
+
+    val fetchInfo: RemoteStorageFetchInfo = createMock(classOf[RemoteStorageFetchInfo])
+    expect(fetchInfo.fetchMaxBytes).andReturn(0)
+    expect(fetchInfo.topicPartition).andReturn(topicPartition)
+    expect(fetchInfo.fetchInfo).andReturn(partitionData)
+    expect(fetchInfo.fetchIsolation).andReturn(FetchTxnCommitted)
+
+    replay(fetchInfo, log, cache)
+
+    val remoteLogManager = new RemoteLogManager(_ => Option(log), (_, _) => {}, rlmConfig, time, brokerId = 1,
+      clusterId, logsDir, brokerTopicStats)
+
+    assertThrows(classOf[OffsetOutOfRangeException], () => remoteLogManager.read(fetchInfo))
+  }
+
+  @Test
+  def testReadPasses(): Unit = {
+    val rsmManager: ClassLoaderAwareRemoteStorageManager = createMock(classOf[ClassLoaderAwareRemoteStorageManager])
+    expect(rsmManager.fetchLogSegment(anyObject(), anyInt())).andReturn(createMock(classOf[FileInputStream]))
+
+    val rlsMetadata: RemoteLogSegmentMetadata = createMock(classOf[RemoteLogSegmentMetadata])
+
+    val cache: LeaderEpochFileCache = createMock(classOf[LeaderEpochFileCache])
+    expect(cache.epochForOffset(anyLong())).andReturn(Option(1))
+
+    val log: Log = createMock(classOf[Log])
+    expect(log.leaderEpochCache).andReturn(Option(cache))
+
+    val partitionData = new PartitionData(0, 0, 0, Optional.empty())
+
+    val fetchInfo: RemoteStorageFetchInfo = createMock(classOf[RemoteStorageFetchInfo])
+    expect(fetchInfo.fetchMaxBytes).andReturn(0)
+    expect(fetchInfo.topicPartition).andReturn(topicPartition)
+    expect(fetchInfo.fetchInfo).andReturn(partitionData)
+    expect(fetchInfo.fetchIsolation).andReturn(FetchTxnCommitted)
+
+    replay(fetchInfo, log, cache, rsmManager)
+
+    val remoteLogManager = new RemoteLogManager(_ => Option(log), (_, _) => {}, rlmConfig, time, brokerId = 1,
+      clusterId, logsDir, brokerTopicStats) {
+      override private[remote] def createRemoteStorageManager(): ClassLoaderAwareRemoteStorageManager =
+        rsmManager
+
+      override def fetchRemoteLogSegmentMetadata(tp: TopicPartition,
+                                                 epochForOffset: Int,
+                                                 offset: Long): Optional[RemoteLogSegmentMetadata] =
+        Optional.of(rlsMetadata)
+
+      override def lookupPositionForOffset(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                                           offset: Long): Int = 1
+
+      override private[remote] def findFirstBatch(remoteLogInputStream: RemoteLogInputStream, offset: Long): RecordBatch = null
+    }
+
+    val fetchDataInfo = remoteLogManager.read(fetchInfo)
+    assertEquals(0, fetchDataInfo.fetchOffsetMetadata.messageOffset)
+    assertEquals(MemoryRecords.EMPTY, fetchDataInfo.records)
+    assertEquals(Some(List.empty), fetchDataInfo.abortedTransactions)
   }
 
   private def listRemoteLogSegmentMetadataByTime(segmentCount: Int,


### PR DESCRIPTION
This is a backport of the changes in obtaining leader epochs from trunk [PR](https://github.com/apache/kafka/pull/11390).

Resolves https://github.com/satishd/kafka/issues/30
