### PR TITLE
Account for offset overlaps in RemoteLog deletion by size

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1829,7 +1829,7 @@ class Log(@volatile private var _dir: File,
             throw new KafkaException("Tiered storage is supported only with versions supporting leader epochs, that means RecordVersion must be >= 2.")
           }
 
-          maybeRemoteLogManager.get.findOffsetByTimestamp(topicPartition, targetTimestamp, logStartOffset, leaderEpochCache.get)
+          maybeRemoteLogManager.get.findOffsetByTimestamp(topicPartition, targetTimestamp, logStartOffset, leaderEpochCache.get, logEndOffset)
         } else None
 
         if (remoteOffset.nonEmpty) {
@@ -2070,6 +2070,11 @@ class Log(@volatile private var _dir: File,
    * See log#size for why such segments might exist
    */
   def validLogSegmentsSize: Long = Log.sizeInBytes(logSegments.filter(_.baseOffset >= localLogStartOffset))
+
+  /**
+   * The size of the log in bytes for segments not yet in remote storage
+   */
+  def localOnlyLogSegmentsSize: Long = Log.sizeInBytes(logSegments.filter(_.baseOffset > highestOffsetWithRemoteIndex))
 
   /**
    * The offset metadata of the next message that will be appended to the log

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -524,15 +524,110 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         updateRemoteLogStartOffset(topicPartition, remoteLogStartOffset)
       }
 
+      /*
+      A segment has leader epochs (remote leader epochs). A partition leader has leader epochs (local leader epochs).
+      For a segment to have a good lineage its leader epochs must be within the boundaries of the leader epochs
+      of the partition leader.
+      The first leader epoch in the segment always starts at the first offset of
+      the segment even if the partition leader's leader epoch started at an earlier log offset.
+      The last leader epoch in the segment always finishes at the last offset of
+      the segment even if the partition leader's leader epoch finishes at a further log offset.
+
+      CORRECT
+      Remote:             i1 ===================== i2
+      Local :        <=== j1 ======================================== j2 ===>
+
+      CORRECT
+      Remote:                                i1 ===================== i2
+      Local :        <=== j1 ======================================== j2 ===>
+
+      CORRECT
+      Remote:                      i1 ===================== i2
+      Local :        <=== j1 ======================================== j2 ===>
+
+      The below is a situation where the remote segment has the same leader epoch as the currently
+      ongoing local leader epoch.
+      CORRECT
+      Remote:                                i1 ===================== i2
+      Local :        <=== j1 ===============================================>
+
+      INCORRECT
+      Remote:                                       i1 ===================== i2
+      Local :        <=== j1 ======================================== j2 ===>
+
+      INCORRECT
+      Remote:   i1 ===================== i2
+      Local :        <=== j1 ======================================== j2 ===>
+      */
+      def doesRemoteSegmentHaveGoodLineage(validEpochs: util.TreeMap[Integer, lang.Long],
+                                           segmentMetadata: RemoteLogSegmentMetadata,
+                                           logEndOffset: lang.Long): Boolean = {
+        val segmentEpochs = segmentMetadata.segmentLeaderEpochs()
+        val segmentEndOffset = segmentMetadata.endOffset()
+        val firstSegmentEpochEntry = segmentEpochs.firstEntry()
+        segmentEpochs.entrySet().stream()
+          .allMatch(entry => {
+            val segmentEpochKey = entry.getKey
+            val segmentEpochStartOffset = entry.getValue
+            if (validEpochs.containsKey(segmentEpochKey)) {
+              val validEpochStartOffset = validEpochs.get(segmentEpochKey)
+              val validEpochEndEntry = validEpochs.higherEntry(segmentEpochKey)
+              val remoteEndEntry = segmentEpochs.higherEntry(segmentEpochKey)
+
+              if (validEpochEndEntry == null && remoteEndEntry != null) {
+                // Remote has more entries than local
+                // This should be impossible but we are erring on the side of defining the behaviour
+                val remoteLogSegmentId = segmentMetadata.remoteLogSegmentId()
+                val topicIdPartition = segmentMetadata.topicIdPartition()
+                val extraneousSegmentLeaderEpoch = remoteEndEntry.getKey
+                warn(s"[Segment $remoteLogSegmentId; TopicPartition $topicIdPartition]: Segment has at least one more leader epoch ($extraneousSegmentLeaderEpoch) than locally ($segmentEpochKey)")
+                false
+              } else if (validEpochEndEntry != null && remoteEndEntry == null) {
+                // Remote has fewer entries than local
+                segmentEpochStartOffset >= validEpochStartOffset && segmentEndOffset < validEpochEndEntry.getValue
+              } else if (validEpochEndEntry != null && remoteEndEntry != null) {
+                // This is not the active leader epoch for both remote and local
+                if (firstSegmentEpochEntry.getKey == segmentEpochKey) {
+                  remoteEndEntry.getKey == validEpochEndEntry.getKey &&
+                    segmentEpochStartOffset >= validEpochStartOffset &&
+                    remoteEndEntry.getValue <= validEpochEndEntry.getValue
+                } else {
+                  remoteEndEntry.getKey == validEpochEndEntry.getKey &&
+                    segmentEpochStartOffset == validEpochStartOffset &&
+                    remoteEndEntry.getValue <= validEpochEndEntry.getValue
+                }
+              } else {
+                // This is the active leader epoch
+                segmentEndOffset < logEndOffset
+              }
+            } else {
+              val remoteLogSegmentId = segmentMetadata.remoteLogSegmentId()
+              val topicIdPartition = segmentMetadata.topicIdPartition()
+              warn(s"[Segment $remoteLogSegmentId; TopicPartition $topicIdPartition]: Segment has a leader epoch ($segmentEpochKey) not found locally")
+              false
+            }
+          })
+      }
+
       def totalLogSize(segmentMetadataList: scala.Seq[RemoteLogSegmentMetadata], log: Log): Long = {
         val localLogStartOffset = log.localLogStartOffset // Cache the value
+
+        val validLeaderEpochs = fromLeaderEpochCacheToEpochs(log)
+
         val remoteOnlyLogSize = segmentMetadataList
           .filter(_.endOffset() < localLogStartOffset)
+          .filter(segmentMetadata => {
+            doesRemoteSegmentHaveGoodLineage(validLeaderEpochs, segmentMetadata, log.logEndOffset)
+          })
           .map(_.segmentSizeInBytes()).sum
 
         val localLogSize = log.validLogSegmentsSize
 
         localLogSize + remoteOnlyLogSize
+      }
+
+      def fromLeaderEpochCacheToEpochs(log: Log): util.TreeMap[Integer, lang.Long] = {
+        log.leaderEpochCache.map(_.getEpochs).getOrElse(new util.TreeMap)
       }
 
       try {

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -367,6 +367,98 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     checkpoint
   }
 
+  /*
+A segment has leader epochs (remote leader epochs). A partition leader has leader epochs (local leader epochs).
+For a segment to have a good lineage its leader epochs must be within the boundaries of the leader epochs
+of the partition leader.
+The first leader epoch in the segment always starts at the first offset of
+the segment even if the partition leader's leader epoch started at an earlier log offset.
+The last leader epoch in the segment always finishes at the last offset of
+the segment even if the partition leader's leader epoch finishes at a further log offset.
+
+CORRECT
+Remote:             i1 ===================== i2
+Local :        <=== j1 ======================================== j2 ===>
+
+CORRECT
+Remote:                                i1 ===================== i2
+Local :        <=== j1 ======================================== j2 ===>
+
+CORRECT
+Remote:                      i1 ===================== i2
+Local :        <=== j1 ======================================== j2 ===>
+
+The below is a situation where the remote segment has the same leader epoch as the currently
+ongoing local leader epoch.
+CORRECT
+Remote:                                i1 ===================== i2
+Local :        <=== j1 ===============================================>
+
+INCORRECT
+Remote:                                       i1 ===================== i2
+Local :        <=== j1 ======================================== j2 ===>
+
+INCORRECT
+Remote:   i1 ===================== i2
+Local :        <=== j1 ======================================== j2 ===>
+*/
+  private[remote] def isRemoteSegmentConsistentWithLeaderLineage(validEpochs: util.TreeMap[Integer, lang.Long],
+                                                                 segmentMetadata: RemoteLogSegmentMetadata,
+                                                                 logEndOffset: lang.Long): lang.Boolean = {
+    val segmentEpochs = segmentMetadata.segmentLeaderEpochs()
+    val segmentEndOffset = segmentMetadata.endOffset()
+    val firstEpochInSegmentEntry = segmentEpochs.firstEntry()
+    segmentEpochs.entrySet().stream()
+      .allMatch(entry => {
+        val segmentEpochKey = entry.getKey
+        val segmentEpochStartOffset = entry.getValue
+        if (validEpochs.containsKey(segmentEpochKey)) {
+          val validEpochStartOffset = validEpochs.get(segmentEpochKey)
+          val validEpochNextEntry = validEpochs.higherEntry(segmentEpochKey)
+          val remoteSegmentEpochNextEntry = segmentEpochs.higherEntry(segmentEpochKey)
+
+          if (validEpochNextEntry == null && remoteSegmentEpochNextEntry != null) {
+            // Segment in remote has a greater leader epoch than local.
+            val remoteLogSegmentId = segmentMetadata.remoteLogSegmentId()
+            val topicIdPartition = segmentMetadata.topicIdPartition()
+            val extraneousSegmentLeaderEpoch = remoteSegmentEpochNextEntry.getKey
+            warn(s"[Segment $remoteLogSegmentId; TopicPartition $topicIdPartition]: Segment has at least one more leader epoch ($extraneousSegmentLeaderEpoch) than locally ($segmentEpochKey)")
+            false
+          } else if (validEpochNextEntry != null && remoteSegmentEpochNextEntry == null) {
+            // Remote has fewer entries than local
+            if (firstEpochInSegmentEntry.getKey == segmentEpochKey) {
+              segmentEpochStartOffset >= validEpochStartOffset && segmentEndOffset < validEpochNextEntry.getValue
+            } else {
+              segmentEpochStartOffset == validEpochStartOffset && segmentEndOffset < validEpochNextEntry.getValue
+            }
+          } else if (validEpochNextEntry != null && remoteSegmentEpochNextEntry != null) {
+            // This is not the active leader epoch for both remote and local
+            if (firstEpochInSegmentEntry.getKey == segmentEpochKey) {
+              remoteSegmentEpochNextEntry.getKey == validEpochNextEntry.getKey &&
+                segmentEpochStartOffset >= validEpochStartOffset &&
+                remoteSegmentEpochNextEntry.getValue == validEpochNextEntry.getValue
+            } else {
+              remoteSegmentEpochNextEntry.getKey == validEpochNextEntry.getKey &&
+                segmentEpochStartOffset == validEpochStartOffset &&
+                remoteSegmentEpochNextEntry.getValue == validEpochNextEntry.getValue
+            }
+          } else {
+            // This is the active leader epoch
+            segmentEndOffset < logEndOffset
+          }
+        } else {
+          // Scenario where the leader epoch found in the segment is not part of the leader epoch history.
+          // This could happened in situations where we have a divergence in leader epoch history between local and
+          // remote tier due to unclean leader election.
+          val remoteLogSegmentId = segmentMetadata.remoteLogSegmentId()
+          val topicIdPartition = segmentMetadata.topicIdPartition()
+          info(s"[Segment $remoteLogSegmentId; TopicPartition $topicIdPartition]: Segment has a leader epoch ($segmentEpochKey) not found locally")
+          false
+        }
+      })
+  }
+
+
   private[remote] class RLMTask(tpId: TopicIdPartition) extends CancellableRunnable with Logging {
     this.logIdent = s"[RemoteLogManager=$brokerId partition=$tpId] "
     @volatile private var leaderEpoch: Int = -1
@@ -524,106 +616,15 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         updateRemoteLogStartOffset(topicPartition, remoteLogStartOffset)
       }
 
-      /*
-      A segment has leader epochs (remote leader epochs). A partition leader has leader epochs (local leader epochs).
-      For a segment to have a good lineage its leader epochs must be within the boundaries of the leader epochs
-      of the partition leader.
-      The first leader epoch in the segment always starts at the first offset of
-      the segment even if the partition leader's leader epoch started at an earlier log offset.
-      The last leader epoch in the segment always finishes at the last offset of
-      the segment even if the partition leader's leader epoch finishes at a further log offset.
-
-      CORRECT
-      Remote:             i1 ===================== i2
-      Local :        <=== j1 ======================================== j2 ===>
-
-      CORRECT
-      Remote:                                i1 ===================== i2
-      Local :        <=== j1 ======================================== j2 ===>
-
-      CORRECT
-      Remote:                      i1 ===================== i2
-      Local :        <=== j1 ======================================== j2 ===>
-
-      The below is a situation where the remote segment has the same leader epoch as the currently
-      ongoing local leader epoch.
-      CORRECT
-      Remote:                                i1 ===================== i2
-      Local :        <=== j1 ===============================================>
-
-      INCORRECT
-      Remote:                                       i1 ===================== i2
-      Local :        <=== j1 ======================================== j2 ===>
-
-      INCORRECT
-      Remote:   i1 ===================== i2
-      Local :        <=== j1 ======================================== j2 ===>
-      */
-      def doesRemoteSegmentHaveGoodLineage(validEpochs: util.TreeMap[Integer, lang.Long],
-                                           segmentMetadata: RemoteLogSegmentMetadata,
-                                           logEndOffset: lang.Long): Boolean = {
-        val segmentEpochs = segmentMetadata.segmentLeaderEpochs()
-        val segmentEndOffset = segmentMetadata.endOffset()
-        val firstSegmentEpochEntry = segmentEpochs.firstEntry()
-        segmentEpochs.entrySet().stream()
-          .allMatch(entry => {
-            val segmentEpochKey = entry.getKey
-            val segmentEpochStartOffset = entry.getValue
-            if (validEpochs.containsKey(segmentEpochKey)) {
-              val validEpochStartOffset = validEpochs.get(segmentEpochKey)
-              val validEpochEndEntry = validEpochs.higherEntry(segmentEpochKey)
-              val remoteEndEntry = segmentEpochs.higherEntry(segmentEpochKey)
-
-              if (validEpochEndEntry == null && remoteEndEntry != null) {
-                // Remote has more entries than local
-                // This should be impossible but we are erring on the side of defining the behaviour
-                val remoteLogSegmentId = segmentMetadata.remoteLogSegmentId()
-                val topicIdPartition = segmentMetadata.topicIdPartition()
-                val extraneousSegmentLeaderEpoch = remoteEndEntry.getKey
-                warn(s"[Segment $remoteLogSegmentId; TopicPartition $topicIdPartition]: Segment has at least one more leader epoch ($extraneousSegmentLeaderEpoch) than locally ($segmentEpochKey)")
-                false
-              } else if (validEpochEndEntry != null && remoteEndEntry == null) {
-                // Remote has fewer entries than local
-                segmentEpochStartOffset >= validEpochStartOffset && segmentEndOffset < validEpochEndEntry.getValue
-              } else if (validEpochEndEntry != null && remoteEndEntry != null) {
-                // This is not the active leader epoch for both remote and local
-                if (firstSegmentEpochEntry.getKey == segmentEpochKey) {
-                  remoteEndEntry.getKey == validEpochEndEntry.getKey &&
-                    segmentEpochStartOffset >= validEpochStartOffset &&
-                    remoteEndEntry.getValue <= validEpochEndEntry.getValue
-                } else {
-                  remoteEndEntry.getKey == validEpochEndEntry.getKey &&
-                    segmentEpochStartOffset == validEpochStartOffset &&
-                    remoteEndEntry.getValue <= validEpochEndEntry.getValue
-                }
-              } else {
-                // This is the active leader epoch
-                segmentEndOffset < logEndOffset
-              }
-            } else {
-              val remoteLogSegmentId = segmentMetadata.remoteLogSegmentId()
-              val topicIdPartition = segmentMetadata.topicIdPartition()
-              warn(s"[Segment $remoteLogSegmentId; TopicPartition $topicIdPartition]: Segment has a leader epoch ($segmentEpochKey) not found locally")
-              false
-            }
-          })
-      }
-
-      def totalLogSize(segmentMetadataList: scala.Seq[RemoteLogSegmentMetadata], log: Log): Long = {
-        val localLogStartOffset = log.localLogStartOffset // Cache the value
-
+      def calculateTotalLogSize(segmentMetadataList: scala.Seq[RemoteLogSegmentMetadata], log: Log): Long = {
         val validLeaderEpochs = fromLeaderEpochCacheToEpochs(log)
 
         val remoteOnlyLogSize = segmentMetadataList
-          .filter(_.endOffset() < localLogStartOffset)
-          .filter(segmentMetadata => {
-            doesRemoteSegmentHaveGoodLineage(validLeaderEpochs, segmentMetadata, log.logEndOffset)
-          })
+          .filter(isRemoteSegmentConsistentWithLeaderLineage(validLeaderEpochs, _, log.logEndOffset))
+          .distinctBy(_.remoteLogSegmentId.id())
           .map(_.segmentSizeInBytes()).sum
 
-        val localLogSize = log.validLogSegmentsSize
-
-        localLogSize + remoteOnlyLogSize
+        log.localOnlyLogSegmentsSize + remoteOnlyLogSize
       }
 
       def fromLeaderEpochCacheToEpochs(log: Log): util.TreeMap[Integer, lang.Long] = {
@@ -634,62 +635,69 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         // cleanup remote log segments and update the log start offset if applicable.
         // Compute total size, this can be pushed to RLMM by introducing a new method instead of going through
         // the collection every time.
-        val segmentMetadataList = remoteLogMetadataManager.listRemoteLogSegments(tpId).asScala.toSeq
-        if (segmentMetadataList.nonEmpty) {
-          fetchLog(tpId.topicPartition()).foreach { log =>
-            val retentionMs = log.config.retentionMs
-            val totalSize = totalLogSize(segmentMetadataList, log)
 
-            val (checkTimestampRetention, cleanupTs) = (retentionMs > -1, time.milliseconds() - retentionMs)
-            val checkSizeRetention = log.config.retentionSize > -1
-            var remainingSize = totalSize - log.config.retentionSize
-            var logStartOffset: Option[Long] = None
+        fetchLog(tpId.topicPartition()).foreach { log =>
+          val retentionMs = log.config.retentionMs
+          val (checkTimestampRetention, cleanupTs) = (retentionMs > -1, time.milliseconds() - retentionMs)
 
-            def deleteRetentionTimeBreachedSegments(metadata: RemoteLogSegmentMetadata): Boolean = {
-              val isSegmentDeleted = deleteRemoteLogSegment(
-                metadata, checkTimestampRetention && _.maxTimestampMs() <= cleanupTs)
-              if (isSegmentDeleted) {
-                remainingSize = Math.max(0, remainingSize - metadata.segmentSizeInBytes())
-                // It is fine to have logStartOffset as `metadata.endOffset() + 1` as the segment offset intervals
-                // are ascending with in an epoch.
-                logStartOffset = Some(metadata.endOffset() + 1)
-                info(s"Deleted remote log segment ${metadata.remoteLogSegmentId()} due to retention time " +
-                  s"${retentionMs}ms breach based on the largest record timestamp in the segment")
-              }
-              isSegmentDeleted
+          val shouldDeleteBySize = log.config.retentionSize > -1
+          val segmentMetadataList = log.leaderEpochCache.get.epochEntries.iterator
+            .flatMap(epochEntry => remoteLogMetadataManager.listRemoteLogSegments(tpId, epochEntry.epoch).asScala).toSeq
+          val totalSize = calculateTotalLogSize(segmentMetadataList, log)
+          var remainingSize =
+            if (shouldDeleteBySize) totalSize - log.config.retentionSize
+            else 0
+
+          var logStartOffset: Option[Long] = None
+
+          def deleteRetentionTimeBreachedSegments(metadata: RemoteLogSegmentMetadata): Boolean = {
+            val isSegmentDeleted = deleteRemoteLogSegment(
+              metadata, checkTimestampRetention && _.maxTimestampMs() <= cleanupTs)
+            if (isSegmentDeleted) {
+              remainingSize = Math.max(0, remainingSize - metadata.segmentSizeInBytes())
+              // It is fine to have logStartOffset as `metadata.endOffset() + 1` as the segment offset intervals
+              // are ascending with in an epoch.
+              logStartOffset = Some(metadata.endOffset() + 1)
+              info(s"Deleted remote log segment ${metadata.remoteLogSegmentId()} due to retention time " +
+                s"${retentionMs}ms breach based on the largest record timestamp in the segment")
             }
-
-            def deleteRetentionSizeBreachedSegments(metadata: RemoteLogSegmentMetadata): Boolean = {
-              val isSegmentDeleted = deleteRemoteLogSegment(metadata, metadata => {
-                // Assumption that segments contain size > 0
-                if (checkSizeRetention && remainingSize > 0) {
-                  remainingSize -= metadata.segmentSizeInBytes()
-                  remainingSize >= 0
-                } else false
-              })
-              if (isSegmentDeleted) {
-                logStartOffset = Some(metadata.endOffset() + 1)
-                info(s"Deleted remote log segment ${metadata.remoteLogSegmentId()} due to retention size " +
-                  s"${log.config.retentionSize} breach. Log size after deletion will be " +
-                  s"${remainingSize + log.config.retentionSize}.")
-              }
-              isSegmentDeleted
-            }
-
-            log.leaderEpochCache.foreach { cache =>
-              cache.epochEntries.find { epochEntry =>
-                val segmentsIterator = remoteLogMetadataManager.listRemoteLogSegments(tpId, epochEntry.epoch)
-                var isSegmentDeleted = true
-                while (isSegmentDeleted && segmentsIterator.hasNext) {
-                  val metadata = segmentsIterator.next()
-                  isSegmentDeleted = deleteRetentionTimeBreachedSegments(metadata) ||
-                    deleteRetentionSizeBreachedSegments(metadata)
-                }
-                !isSegmentDeleted
-              }
-            }
-            logStartOffset.foreach(handleLogStartOffsetUpdate(tpId.topicPartition(), _))
+            isSegmentDeleted
           }
+
+          def deleteRetentionSizeBreachedSegments(metadata: RemoteLogSegmentMetadata): Boolean = {
+            val isSegmentDeleted = deleteRemoteLogSegment(metadata, metadata => {
+              // Assumption that segments contain size > 0
+              if (shouldDeleteBySize && remainingSize > 0) {
+                remainingSize -= metadata.segmentSizeInBytes()
+                remainingSize >= 0
+              } else false
+            })
+            if (isSegmentDeleted) {
+              logStartOffset = Some(metadata.endOffset() + 1)
+              info(s"Deleted remote log segment ${metadata.remoteLogSegmentId()} due to retention size " +
+                s"${log.config.retentionSize} breach. Log size after deletion will be " +
+                s"${remainingSize + log.config.retentionSize}.")
+            }
+            isSegmentDeleted
+          }
+
+          val validLeaderEpochs = fromLeaderEpochCacheToEpochs(log)
+          log.leaderEpochCache.foreach { cache =>
+            cache.epochEntries.find { epochEntry =>
+              val segmentsIterator =
+                remoteLogMetadataManager.listRemoteLogSegments(tpId, epochEntry.epoch).asScala
+                  .filter(isRemoteSegmentConsistentWithLeaderLineage(validLeaderEpochs, _, log.logEndOffset))
+
+              var isSegmentDeleted = true
+              while (isSegmentDeleted && segmentsIterator.hasNext) {
+                val metadata = segmentsIterator.next()
+                isSegmentDeleted = deleteRetentionTimeBreachedSegments(metadata) ||
+                  deleteRetentionSizeBreachedSegments(metadata)
+              }
+              !isSegmentDeleted
+            }
+          }
+          logStartOffset.foreach(handleLogStartOffsetUpdate(tpId.topicPartition(), _))
         }
       } catch {
         case ex: Exception =>
@@ -968,26 +976,27 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
    * @return the timestamp and offset of the first message that meets the requirements. None will be returned if there is no such message.
    */
   def findOffsetByTimestamp(tp: TopicPartition, timestamp: Long, startingOffset: Long,
-                            leaderEpochCache: LeaderEpochFileCache): Option[TimestampAndOffset] = {
-    topicPartitionIds.get(tp) match {
-      case Some(uuid) =>
-        val topicIdPartition = new TopicIdPartition(uuid, tp)
-        // Get the respective epoch in which the starting offset exists.
-        var maybeEpoch = leaderEpochCache.epochForOffset(startingOffset)
-        while (maybeEpoch.nonEmpty) {
-          val epoch = maybeEpoch.get
-          remoteLogMetadataManager.listRemoteLogSegments(topicIdPartition, epoch).asScala.foreach(rlsMetadata =>
-            if (rlsMetadata.maxTimestampMs() >= timestamp && rlsMetadata.endOffset() >= startingOffset) {
-              val timestampOffset = lookupTimestamp(rlsMetadata, timestamp, startingOffset)
-              if (timestampOffset.isDefined)
-                return timestampOffset
-            }
-          )
+                            leaderEpochCache: LeaderEpochFileCache, logEndOffset: Long): Option[TimestampAndOffset] = {
+    val topicId = topicPartitionIds.get(tp)
+    if (topicId.isEmpty) {
+      throw new KafkaException("Topic id does not exist for topic partition: " + tp)
+    }
+    // Get the respective epoch in which the starting offset exists.
+    var maybeEpoch = leaderEpochCache.epochForOffset(startingOffset)
+    while (maybeEpoch.nonEmpty) {
+      val epoch = maybeEpoch.get
+      remoteLogMetadataManager.listRemoteLogSegments(new TopicIdPartition(topicId.get, tp), epoch).asScala
+        .foreach(rlsMetadata =>
+          if (isRemoteSegmentConsistentWithLeaderLineage(leaderEpochCache.getEpochs, rlsMetadata, logEndOffset) &&
+            rlsMetadata.maxTimestampMs() >= timestamp && rlsMetadata.endOffset() >= startingOffset) {
+            val timestampOffset = lookupTimestamp(rlsMetadata, timestamp, startingOffset)
+            if (timestampOffset.isDefined)
+              return timestampOffset
+          }
+        )
 
-          // Move to the next epoch if not found with the current epoch.
-          maybeEpoch = leaderEpochCache.findNextEpoch(epoch)
-        }
-      case None => throw new KafkaException("Topic id does not exist for topic partition: " + tp);
+      // Move to the next epoch if not found with the current epoch.
+      maybeEpoch = leaderEpochCache.findNextEpoch(epoch)
     }
     None
   }

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -524,6 +524,17 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         updateRemoteLogStartOffset(topicPartition, remoteLogStartOffset)
       }
 
+      def totalLogSize(segmentMetadataList: scala.Seq[RemoteLogSegmentMetadata], log: Log): Long = {
+        val localLogStartOffset = log.localLogStartOffset // Cache the value
+        val remoteOnlyLogSize = segmentMetadataList
+          .filter(_.endOffset() < localLogStartOffset)
+          .map(_.segmentSizeInBytes()).sum
+
+        val localLogSize = log.validLogSegmentsSize
+
+        localLogSize + remoteOnlyLogSize
+      }
+
       try {
         // cleanup remote log segments and update the log start offset if applicable.
         // Compute total size, this can be pushed to RLMM by introducing a new method instead of going through
@@ -532,7 +543,8 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         if (segmentMetadataList.nonEmpty) {
           fetchLog(tpId.topicPartition()).foreach { log =>
             val retentionMs = log.config.retentionMs
-            val totalSize = log.size + segmentMetadataList.map(_.segmentSizeInBytes()).sum
+            val totalSize = totalLogSize(segmentMetadataList, log)
+
             val (checkTimestampRetention, cleanupTs) = (retentionMs > -1, time.milliseconds() - retentionMs)
             val checkSizeRetention = log.config.retentionSize > -1
             var remainingSize = totalSize - log.config.retentionSize

--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -18,7 +18,6 @@ package kafka.server.epoch
 
 import java.util
 import java.util.concurrent.locks.ReentrantReadWriteLock
-
 import kafka.server.checkpoints.LeaderEpochCheckpoint
 import kafka.utils.CoreUtils._
 import kafka.utils.Logging
@@ -327,6 +326,12 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
 
   // Visible for testing
   def epochEntries: Seq[EpochEntry] = epochs.values.asScala.toSeq
+
+  def getEpochs: util.TreeMap[Integer, java.lang.Long] = {
+    val navigableMap = new util.TreeMap[Integer, java.lang.Long]()
+    epochs.values().forEach(entry => navigableMap.put(entry.epoch, entry.startOffset))
+    navigableMap
+  }
 
   private def flush(): Unit = {
     checkpoint.write(epochs.values.asScala)

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -2772,7 +2772,7 @@ class LogTest {
     val rlm: RemoteLogManager = EasyMock.niceMock(classOf[RemoteLogManager])
     val remoteTimestampAndOffset = new TimestampAndOffset(2, 2L, Optional.of(2))
 
-    EasyMock.expect(rlm.findOffsetByTimestamp(anyObject(), anyObject(), anyObject(), anyObject()))
+    EasyMock.expect(rlm.findOffsetByTimestamp(anyObject(), anyObject(), anyObject(), anyObject(), anyObject()))
       .andReturn(Some(remoteTimestampAndOffset))
       .andReturn(None)
     EasyMock.replay(rlm)

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -546,6 +546,8 @@ class RemoteLogManagerTest {
     epochCheckpoints.foreach { case (epoch, startOffset) => cache.assign(epoch, startOffset) }
     val currentLeaderEpoch = epochCheckpoints.last._1
 
+    val localLogSegmentsSize = 500L
+
     val logConfig: LogConfig = createMock(classOf[LogConfig])
     expect(logConfig.retentionMs).andReturn(1).anyTimes()
     expect(logConfig.retentionSize).andReturn(-1).anyTimes()
@@ -553,7 +555,9 @@ class RemoteLogManagerTest {
     val log: Log = createMock(classOf[Log])
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
-    expect(log.validLogSegmentsSize).andReturn(0).anyTimes()
+    expect(log.logEndOffset).andReturn(segmentCount * recordsPerSegment + 1).anyTimes()
+    expect(log.size).andReturn(0).anyTimes()
+    expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
     val localLogStartOffset = recordsPerSegment * segmentCount
     expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
 
@@ -617,6 +621,7 @@ class RemoteLogManagerTest {
     val log: Log = createMock(classOf[Log])
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
+    expect(log.logEndOffset).andReturn(segmentCount * recordsPerSegment + 1).anyTimes()
     expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
     val localLogStartOffset = recordsPerSegment * segmentCount - overlappingLogSegmentsSize
     expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
@@ -630,7 +635,7 @@ class RemoteLogManagerTest {
         override private[remote] def createRemoteStorageManager(): ClassLoaderAwareRemoteStorageManager = rsmManager
         override private[remote] def createRemoteLogMetadataManager() = rlmmManager
       }
-    val segmentMetadataList = listRemoteLogSegmentMetadata(segmentCount, recordsPerSegment)
+    val segmentMetadataList = listRemoteLogSegmentMetadataWithFaultyRemoteSegments(segmentCount, recordsPerSegment)
     expect(rlmmManager.highestOffsetForEpoch(EasyMock.eq(topicIdPartition), anyInt()))
       .andReturn(Optional.empty()).anyTimes()
     expect(rlmmManager.listRemoteLogSegments(topicIdPartition)).andReturn(segmentMetadataList.iterator.asJava).anyTimes()
@@ -683,9 +688,11 @@ class RemoteLogManagerTest {
     val log: Log = createMock(classOf[Log])
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
+    expect(log.logEndOffset).andReturn(segmentCount * recordsPerSegment + 1).anyTimes()
     expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
     val localLogStartOffset = recordsPerSegment * segmentCount - overlappingLogSegmentsSize
     expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
+
 
     var logStartOffset: Option[Long] = None
     val rsmManager: ClassLoaderAwareRemoteStorageManager = createMock(classOf[ClassLoaderAwareRemoteStorageManager])
@@ -1010,6 +1017,59 @@ class RemoteLogManagerTest {
 
   private def listRemoteLogSegmentMetadata(segmentCount: Int, recordsPerSegment: Int): List[RemoteLogSegmentMetadata] = {
     listRemoteLogSegmentMetadataByTime(segmentCount, 0, recordsPerSegment)
+  }
+
+  private def faultyFirstEntry(firstEntry: RemoteLogSegmentMetadata): RemoteLogSegmentMetadata = {
+    val remoteEpochs = firstEntry.segmentLeaderEpochs()
+    val firstEpoch = remoteEpochs.firstEntry()
+    val secondEpoch = remoteEpochs.higherEntry(firstEpoch.getKey)
+    val faultyEpochs = new util.TreeMap[Integer, lang.Long]()
+    faultyEpochs.put(firstEpoch.getKey, firstEpoch.getValue)
+    faultyEpochs.put(secondEpoch.getKey, secondEpoch.getValue + 1)
+    faultyEpochs.putAll(remoteEpochs.subMap(secondEpoch.getKey, false, remoteEpochs.lastKey(), true))
+    new RemoteLogSegmentMetadata(
+      firstEntry.remoteLogSegmentId(),
+      firstEntry.startOffset(),
+      firstEntry.endOffset(),
+      firstEntry.maxTimestampMs(),
+      firstEntry.brokerId(),
+      firstEntry.eventTimestampMs(),
+      firstEntry.segmentSizeInBytes(),
+      faultyEpochs
+    )
+  }
+
+  private def faultyLastEntry(lastEntry: RemoteLogSegmentMetadata): RemoteLogSegmentMetadata = {
+    val remoteEpochs = lastEntry.segmentLeaderEpochs()
+    val lastEpoch = remoteEpochs.lastEntry()
+    val faultyEpochs = new util.TreeMap[Integer, lang.Long]()
+    faultyEpochs.putAll(remoteEpochs.subMap(remoteEpochs.firstKey(), true, remoteEpochs.lastKey(), false))
+    faultyEpochs.put(lastEpoch.getKey, lastEpoch.getValue - 1)
+    new RemoteLogSegmentMetadata(
+      lastEntry.remoteLogSegmentId(),
+      lastEntry.startOffset(),
+      lastEntry.endOffset(),
+      lastEntry.maxTimestampMs(),
+      lastEntry.brokerId(),
+      lastEntry.eventTimestampMs(),
+      lastEntry.segmentSizeInBytes(),
+      faultyEpochs
+    )
+  }
+
+  private def listRemoteLogSegmentMetadataWithFaultyRemoteSegments(segmentCount: Int, recordsPerSegment: Int): List[RemoteLogSegmentMetadata] = {
+    val correctList = listRemoteLogSegmentMetadata(segmentCount, recordsPerSegment)
+    val firstEntry = correctList(0)
+    val lastEntry = correctList(correctList.length - 1)
+    // We want the first leader epoch in the first entry to end higher than the local one
+    // and the last leader epoch in the last entry to start lower than the local one.
+    // To achieve the first we need to increase the start offset of the second leader epoch
+    // in the remote entry by one.
+    // To achieve the second we need to decrease the start offset of the last leader epoch
+    // by one.
+    val crookedFirstEntry = faultyFirstEntry(firstEntry)
+    val crookedLastEntry = faultyLastEntry(lastEntry)
+    crookedFirstEntry +: correctList :+ crookedLastEntry
   }
 
   private def nonExistentTempFile(): File = {

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -553,7 +553,9 @@ class RemoteLogManagerTest {
     val log: Log = createMock(classOf[Log])
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
-    expect(log.size).andReturn(0).anyTimes()
+    expect(log.validLogSegmentsSize).andReturn(0).anyTimes()
+    val localLogStartOffset = recordsPerSegment * segmentCount
+    expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
 
     var logStartOffset: Option[Long] = None
     val rsmManager: ClassLoaderAwareRemoteStorageManager = createMock(classOf[ClassLoaderAwareRemoteStorageManager])
@@ -607,7 +609,7 @@ class RemoteLogManagerTest {
 
     val overlappingLogSegmentsSize = 3 * recordsPerSegment
     val localLogSegmentsSize = 500L + overlappingLogSegmentsSize
-    val retentionSize = (segmentCount - deletableSegmentCount) * 100 + (localLogSegmentsSize - overlappingLogSegmentsSize)
+    val retentionSize = ((segmentCount - deletableSegmentCount) * recordsPerSegment) + (localLogSegmentsSize - overlappingLogSegmentsSize)
     val logConfig: LogConfig = createMock(classOf[LogConfig])
     expect(logConfig.retentionMs).andReturn(-1).anyTimes()
     expect(logConfig.retentionSize).andReturn(retentionSize).anyTimes()
@@ -671,8 +673,9 @@ class RemoteLogManagerTest {
     epochCheckpoints.foreach { case (epoch, startOffset) => cache.assign(epoch, startOffset) }
     val currentLeaderEpoch = epochCheckpoints.last._1
 
-    val localLogSegmentsSize = 500L
-    val retentionSize = (segmentCount - deletableSegmentCountBySize) * 100 + localLogSegmentsSize
+    val overlappingLogSegmentsSize = 3 * recordsPerSegment
+    val localLogSegmentsSize = 500L + overlappingLogSegmentsSize
+    val retentionSize = (segmentCount - deletableSegmentCountBySize) * recordsPerSegment + (localLogSegmentsSize - overlappingLogSegmentsSize)
     val logConfig: LogConfig = createMock(classOf[LogConfig])
     expect(logConfig.retentionMs).andReturn(1).anyTimes()
     expect(logConfig.retentionSize).andReturn(retentionSize).anyTimes()
@@ -680,7 +683,9 @@ class RemoteLogManagerTest {
     val log: Log = createMock(classOf[Log])
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
-    expect(log.size).andReturn(localLogSegmentsSize).anyTimes()
+    expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
+    val localLogStartOffset = recordsPerSegment * segmentCount - overlappingLogSegmentsSize
+    expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
 
     var logStartOffset: Option[Long] = None
     val rsmManager: ClassLoaderAwareRemoteStorageManager = createMock(classOf[ClassLoaderAwareRemoteStorageManager])

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -605,8 +605,9 @@ class RemoteLogManagerTest {
     epochCheckpoints.foreach { case (epoch, startOffset) => cache.assign(epoch, startOffset) }
     val currentLeaderEpoch = epochCheckpoints.last._1
 
-    val localLogSegmentsSize = 500L
-    val retentionSize = (segmentCount - deletableSegmentCount) * 100 + localLogSegmentsSize
+    val overlappingLogSegmentsSize = 3 * recordsPerSegment
+    val localLogSegmentsSize = 500L + overlappingLogSegmentsSize
+    val retentionSize = (segmentCount - deletableSegmentCount) * 100 + (localLogSegmentsSize - overlappingLogSegmentsSize)
     val logConfig: LogConfig = createMock(classOf[LogConfig])
     expect(logConfig.retentionMs).andReturn(-1).anyTimes()
     expect(logConfig.retentionSize).andReturn(retentionSize).anyTimes()
@@ -614,7 +615,9 @@ class RemoteLogManagerTest {
     val log: Log = createMock(classOf[Log])
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
-    expect(log.size).andReturn(localLogSegmentsSize).anyTimes()
+    expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
+    val localLogStartOffset = recordsPerSegment * segmentCount - overlappingLogSegmentsSize
+    expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
 
     var logStartOffset: Option[Long] = None
     val rsmManager: ClassLoaderAwareRemoteStorageManager = createMock(classOf[ClassLoaderAwareRemoteStorageManager])

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -36,7 +36,7 @@ import org.easymock.EasyMock._
 import org.junit.jupiter.api.Assertions.{assertDoesNotThrow, assertEquals, assertFalse, assertThrows, assertTrue}
 import org.junit.jupiter.api.{AfterEach, Test}
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.{Arguments, CsvSource, MethodSource}
 
 import java.io.{File, FileInputStream}
 import java.nio.file.{Files, Paths}
@@ -44,6 +44,58 @@ import java.util.{Collections, Optional, Properties}
 import java.{lang, util}
 import scala.collection.{Seq, mutable}
 import scala.jdk.CollectionConverters._
+
+object RemoteLogManagerTest {
+  def paramProviderForIsRemoteSegmentConsistentWithLeaderLineageTest: java.util.stream.Stream[Arguments] = {
+    def createSegmentMetadata(startOffset: Int,
+                              endOffset: Int,
+                              segmentLeaderEpochs: util.Map[Int, Long]): RemoteLogSegmentMetadata = {
+      val dummyTopicPartitionId = new TopicIdPartition(Uuid.randomUuid(), new TopicPartition("test-topic", 0))
+      new RemoteLogSegmentMetadata(
+        new RemoteLogSegmentId(dummyTopicPartitionId, Uuid.randomUuid()),
+        startOffset,
+        endOffset,
+        10, // dummy maxTimestampMs
+        0, // dummy broker id
+        -1L, // dummy eventTimestampMs
+        1024, // dummy segment size
+        segmentLeaderEpochs.asInstanceOf[util.Map[Integer, lang.Long]])
+    }
+
+    // example of segment which has an epoch starting & ending within it
+    val metadataSeg1 = createSegmentMetadata(0, 10, Map(0 -> 0L, 1 -> 4L, 2 -> 10L).asJava)
+
+    // example of segment where epoch start/end are both lesser/greater than segment start/end
+    val metadataSeg2 = createSegmentMetadata(11, 20, Map(2 -> 11L, 2 -> 20L).asJava)
+
+    // example of segment where segment is the latest segment in remote but does not contain the latest epoch in local
+    val metadataSeg3 = createSegmentMetadata(21, 30, Map(2 -> 21L, 5 -> 25L).asJava)
+
+    // example of inconsistent segment, case: when remote segment has a higher epoch than local leader segment
+    val inconsistentSegment1 = createSegmentMetadata(31, 40, Map(5 -> 31L, 10 -> 35L).asJava)
+
+    // example of inconsistent segment, case: when remote segment has an epoch not available in local segment
+    val inconsistentSegment2 = createSegmentMetadata(31, 40, Map(4 -> 31L).asJava)
+
+    // example of inconsistent segment, case: when remote segment has divergence in lineage
+    val inconsistentSegment3 = createSegmentMetadata(0, 10, Map(0 -> 0L, 1 -> 3L).asJava)
+    val inconsistentSegment4 = createSegmentMetadata(0, 10, Map(0 -> 0L, 1 -> 8L).asJava)
+    val inconsistentSegment5 = createSegmentMetadata(21, 30, Map(2 -> 21L, 5 -> 24L).asJava)
+    val inconsistentSegment6 = createSegmentMetadata(21, 30, Map(2 -> 21L, 5 -> 27L).asJava)
+
+    java.util.stream.Stream.of(
+      Arguments.of(true, metadataSeg1),
+      Arguments.of(true, metadataSeg2),
+      Arguments.of(true, metadataSeg3),
+      Arguments.of(false, inconsistentSegment1),
+      Arguments.of(false, inconsistentSegment2),
+      Arguments.of(false, inconsistentSegment3),
+      Arguments.of(false, inconsistentSegment4),
+      Arguments.of(false, inconsistentSegment5),
+      Arguments.of(false, inconsistentSegment6)
+    )
+  }
+}
 
 class RemoteLogManagerTest {
 
@@ -162,6 +214,30 @@ class RemoteLogManagerTest {
     assertEquals(-1L, remoteLogManager.findHighestRemoteOffset(topicIdPartition))
   }
 
+  @ParameterizedTest
+  @MethodSource(Array("paramProviderForIsRemoteSegmentConsistentWithLeaderLineageTest"))
+  def testIsRemoteSegmentConsistentWithLeaderLineage(expectedResult: Boolean,
+                                                     remoteSegment: RemoteLogSegmentMetadata): Unit = {
+    cache.assign(0, 0)
+    cache.assign(1, 4)
+    cache.assign(2, 10)
+    cache.assign(5, 25)
+    cache.assign(6, 35)
+
+    val log: Log = createMock(classOf[Log])
+    val rlmmManager: RemoteLogMetadataManager = createNiceMock(classOf[RemoteLogMetadataManager])
+    val remoteLogManager = new RemoteLogManager(_ => Option(log),
+      (_, _) => {}, rlmConfig, time, 1, clusterId, logsDir, brokerTopicStats) {
+      override private[remote] def createRemoteLogMetadataManager() = rlmmManager
+    }
+
+    val epochCache = cache.getEpochs
+    val result = remoteLogManager.isRemoteSegmentConsistentWithLeaderLineage(epochCache, remoteSegment, 40)
+
+    assertEquals(expectedResult, result,
+      "RemoteSegment consistency check with leader lineage did not match the expected result")
+  }
+
   @Test
   def testFindHighestRemoteOffset(): Unit = {
     cache.assign(0, 0)
@@ -189,9 +265,8 @@ class RemoteLogManagerTest {
     cache.assign(0, 0)
     cache.assign(1, 10)
 
-    def metadata(startOffset: Int, endOffset: Int, maxTimestamp: Int): RemoteLogSegmentMetadata = {
-      val segmentLeaderEpochs = new util.HashMap[Integer, lang.Long]
-      segmentLeaderEpochs.put(0, 0) // Add mock data to satisfy constructor, but not used
+    def metadata(startOffset: Int, endOffset: Int, maxTimestamp: Int,
+                 segmentLeaderEpochs: util.Map[Integer, lang.Long] = Collections.singletonMap(0, 0L)): RemoteLogSegmentMetadata = {
       new RemoteLogSegmentMetadata(new RemoteLogSegmentId(topicIdPartition, Uuid.randomUuid()),
         startOffset, endOffset, maxTimestamp, brokerId,
         -1L, 1024, segmentLeaderEpochs)
@@ -199,13 +274,23 @@ class RemoteLogManagerTest {
 
     val metadata1 = metadata(0, 5, 10)
     val metadata2 = metadata(6, 9, 20)
-    val metadata3 = metadata(10, 15, 15)
+    val metadata3 = metadata(10, 15, 15, Collections.singletonMap(1, 10))
+    // Remote leader epoch 1 starts at offset 9, while local starts at offset 10
+    val metadata4WithBadLineage = metadata(10, 15, 15, Collections.singletonMap(1, 9))
+    // Remote leader epoch 0 finishes at offset 10, while local finishes at offset 9.
+    // Remote leader epoch 1 starts at offset 11, while local starts at offset 10.
+    val remoteLeaderEpochs = new util.HashMap[Integer, lang.Long]()
+    remoteLeaderEpochs.put(0, 9)
+    remoteLeaderEpochs.put(1, 11)
+    val metadata5WithBadLineage = metadata(9, 15, 15, remoteLeaderEpochs)
+
+    val logEndOffset = 16L
 
     val rlmm: RemoteLogMetadataManager = niceMock(classOf[RemoteLogMetadataManager])
     expect(rlmm.listRemoteLogSegments(topicIdPartition, 0))
-      .andAnswer(() => List(metadata1, metadata2).asJava.iterator()).anyTimes()
+      .andAnswer(() => List(metadata1, metadata2, metadata5WithBadLineage).asJava.iterator()).anyTimes()
     expect(rlmm.listRemoteLogSegments(topicIdPartition, 1))
-      .andAnswer(() => List(metadata3).asJava.iterator()).anyTimes()
+      .andAnswer(() => List(metadata3, metadata4WithBadLineage, metadata5WithBadLineage).asJava.iterator()).anyTimes()
 
     def timestampOffsetOption(rlsm: RemoteLogSegmentMetadata): Option[TimestampAndOffset] =
       Some(new TimestampAndOffset(rlsm.maxTimestampMs(), rlsm.endOffset(), Optional.empty()))
@@ -231,21 +316,21 @@ class RemoteLogManagerTest {
 
     // Non-existent topic
     assertThrows(classOf[KafkaException], () => remoteLogManager.findOffsetByTimestamp(
-      new TopicPartition("non-existent", 0), 0, 0, cache))
+      new TopicPartition("non-existent", 0), 0, 0, cache, logEndOffset))
     // In first segment of first leader epoch
-    assertEquals(timestampOffsetOption(metadata1), remoteLogManager.findOffsetByTimestamp(tp, 5, 5, cache))
+    assertEquals(timestampOffsetOption(metadata1), remoteLogManager.findOffsetByTimestamp(tp, 5, 5, cache, logEndOffset))
     // In second segment of first leader epoch
-    assertEquals(timestampOffsetOption(metadata2), remoteLogManager.findOffsetByTimestamp(tp, 15, 5, cache))
+    assertEquals(timestampOffsetOption(metadata2), remoteLogManager.findOffsetByTimestamp(tp, 15, 5, cache, logEndOffset))
     // In next leader epoch
-    assertEquals(timestampOffsetOption(metadata3), remoteLogManager.findOffsetByTimestamp(tp, 5, 10, cache))
+    assertEquals(timestampOffsetOption(metadata3), remoteLogManager.findOffsetByTimestamp(tp, 5, 10, cache, logEndOffset))
     // When timestamps not monotonic
-    assertEquals(timestampOffsetOption(metadata2), remoteLogManager.findOffsetByTimestamp(tp, 15, 8, cache))
-    assertEquals(timestampOffsetOption(metadata3), remoteLogManager.findOffsetByTimestamp(tp, 15, 10, cache))
+    assertEquals(timestampOffsetOption(metadata2), remoteLogManager.findOffsetByTimestamp(tp, 15, 8, cache, logEndOffset))
+    assertEquals(timestampOffsetOption(metadata3), remoteLogManager.findOffsetByTimestamp(tp, 15, 10, cache, logEndOffset))
     // When no such offsets exist
-    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 20, 10, cache))
-    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 16, 15, cache))
-    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 0, 25, cache))
-    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 30, 0, cache))
+    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 20, 10, cache, logEndOffset))
+    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 16, 15, cache, logEndOffset))
+    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 0, 25, cache, logEndOffset))
+    assertEquals(None, remoteLogManager.findOffsetByTimestamp(tp, 30, 0, cache, logEndOffset))
   }
 
   @Test
@@ -557,7 +642,7 @@ class RemoteLogManagerTest {
     expect(log.config).andReturn(logConfig).anyTimes()
     expect(log.logEndOffset).andReturn(segmentCount * recordsPerSegment + 1).anyTimes()
     expect(log.size).andReturn(0).anyTimes()
-    expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
+    expect(log.localOnlyLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
     val localLogStartOffset = recordsPerSegment * segmentCount
     expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
 
@@ -573,7 +658,6 @@ class RemoteLogManagerTest {
     val segmentMetadataList = listRemoteLogSegmentMetadataByTime(segmentCount, deletableSegmentCount, recordsPerSegment)
     expect(rlmmManager.highestOffsetForEpoch(EasyMock.eq(topicIdPartition), anyInt()))
       .andReturn(Optional.empty()).anyTimes()
-    expect(rlmmManager.listRemoteLogSegments(topicIdPartition)).andReturn(segmentMetadataList.iterator.asJava).anyTimes()
     expect(rlmmManager.listRemoteLogSegments(EasyMock.eq(topicIdPartition), anyInt())).andAnswer(() => {
       val leaderEpoch = getCurrentArgument[Int](1)
       if (leaderEpoch == 0)
@@ -611,9 +695,8 @@ class RemoteLogManagerTest {
     epochCheckpoints.foreach { case (epoch, startOffset) => cache.assign(epoch, startOffset) }
     val currentLeaderEpoch = epochCheckpoints.last._1
 
-    val overlappingLogSegmentsSize = 3 * recordsPerSegment
-    val localLogSegmentsSize = 500L + overlappingLogSegmentsSize
-    val retentionSize = ((segmentCount - deletableSegmentCount) * recordsPerSegment) + (localLogSegmentsSize - overlappingLogSegmentsSize)
+    val localOnlyLogSegmentsSize = 500L
+    val retentionSize = (segmentCount - deletableSegmentCount) * 100 + localOnlyLogSegmentsSize
     val logConfig: LogConfig = createMock(classOf[LogConfig])
     expect(logConfig.retentionMs).andReturn(-1).anyTimes()
     expect(logConfig.retentionSize).andReturn(retentionSize).anyTimes()
@@ -622,9 +705,7 @@ class RemoteLogManagerTest {
     expect(log.leaderEpochCache).andReturn(Option(cache)).anyTimes()
     expect(log.config).andReturn(logConfig).anyTimes()
     expect(log.logEndOffset).andReturn(segmentCount * recordsPerSegment + 1).anyTimes()
-    expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
-    val localLogStartOffset = recordsPerSegment * segmentCount - overlappingLogSegmentsSize
-    expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
+    expect(log.localOnlyLogSegmentsSize).andReturn(localOnlyLogSegmentsSize).anyTimes()
 
     var logStartOffset: Option[Long] = None
     val rsmManager: ClassLoaderAwareRemoteStorageManager = createMock(classOf[ClassLoaderAwareRemoteStorageManager])
@@ -638,20 +719,23 @@ class RemoteLogManagerTest {
     val segmentMetadataList = listRemoteLogSegmentMetadataWithFaultyRemoteSegments(segmentCount, recordsPerSegment)
     expect(rlmmManager.highestOffsetForEpoch(EasyMock.eq(topicIdPartition), anyInt()))
       .andReturn(Optional.empty()).anyTimes()
-    expect(rlmmManager.listRemoteLogSegments(topicIdPartition)).andReturn(segmentMetadataList.iterator.asJava).anyTimes()
+
+    val args1 = newCapture[RemoteLogSegmentMetadata](CaptureType.ALL)
+    expect(rsmManager.deleteLogSegmentData(capture(args1))).anyTimes()
+
     expect(rlmmManager.listRemoteLogSegments(EasyMock.eq(topicIdPartition), anyInt())).andAnswer(() => {
       val leaderEpoch = getCurrentArgument[Int](1)
-      if (leaderEpoch == 0)
-        segmentMetadataList.take(1).iterator.asJava
+      if (leaderEpoch < 4)
+        segmentMetadataList.take(2) // First segment is faulty
+          .filterNot(args1.getValues.contains(_)) // Filter out already deleted segments
+          .iterator.asJava
       else if (leaderEpoch == 4)
-        segmentMetadataList.drop(1).iterator.asJava
+        segmentMetadataList.drop(2).filterNot(args1.getValues.contains(_)).iterator.asJava
       else
         Collections.emptyIterator()
     }).anyTimes()
     expect(rlmmManager.updateRemoteLogSegmentMetadata(anyObject(classOf[RemoteLogSegmentMetadataUpdate]))).anyTimes()
 
-    val args1 = newCapture[RemoteLogSegmentMetadata](CaptureType.ALL)
-    expect(rsmManager.deleteLogSegmentData(capture(args1))).anyTimes()
     replay(logConfig, log, rlmmManager, rsmManager)
 
     val rlmTask = new remoteLogManager.RLMTask(topicIdPartition)
@@ -660,8 +744,10 @@ class RemoteLogManagerTest {
 
     assertEquals(deletableSegmentCount, args1.getValues.size())
     if (deletableSegmentCount > 0) {
-      val expectedEndMetadata = segmentMetadataList(deletableSegmentCount-1)
-      assertEquals(segmentMetadataList.head, args1.getValues.asScala.head)
+      val expectedDeletedSegments = segmentMetadataList.drop(1)
+      val expectedEndMetadata = expectedDeletedSegments(deletableSegmentCount-1)
+      // first segment is not in the lineage, so we don't delete it
+      assertEquals(expectedDeletedSegments.head, args1.getValues.asScala.head)
       assertEquals(expectedEndMetadata, args1.getValues.asScala.reverse.head)
       assertEquals(expectedEndMetadata.endOffset()+1, logStartOffset.get)
     }
@@ -678,9 +764,8 @@ class RemoteLogManagerTest {
     epochCheckpoints.foreach { case (epoch, startOffset) => cache.assign(epoch, startOffset) }
     val currentLeaderEpoch = epochCheckpoints.last._1
 
-    val overlappingLogSegmentsSize = 3 * recordsPerSegment
-    val localLogSegmentsSize = 500L + overlappingLogSegmentsSize
-    val retentionSize = (segmentCount - deletableSegmentCountBySize) * recordsPerSegment + (localLogSegmentsSize - overlappingLogSegmentsSize)
+    val localLogSegmentsSize = 500L
+    val retentionSize = (segmentCount - deletableSegmentCountBySize) * 100 + localLogSegmentsSize
     val logConfig: LogConfig = createMock(classOf[LogConfig])
     expect(logConfig.retentionMs).andReturn(1).anyTimes()
     expect(logConfig.retentionSize).andReturn(retentionSize).anyTimes()
@@ -690,8 +775,9 @@ class RemoteLogManagerTest {
     expect(log.config).andReturn(logConfig).anyTimes()
     expect(log.logEndOffset).andReturn(segmentCount * recordsPerSegment + 1).anyTimes()
     expect(log.validLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
-    val localLogStartOffset = recordsPerSegment * segmentCount - overlappingLogSegmentsSize
+    val localLogStartOffset = recordsPerSegment * segmentCount
     expect(log.localLogStartOffset).andReturn(localLogStartOffset).anyTimes()
+    expect(log.localOnlyLogSegmentsSize).andReturn(localLogSegmentsSize).anyTimes()
 
 
     var logStartOffset: Option[Long] = None
@@ -1023,10 +1109,12 @@ class RemoteLogManagerTest {
     val remoteEpochs = firstEntry.segmentLeaderEpochs()
     val firstEpoch = remoteEpochs.firstEntry()
     val secondEpoch = remoteEpochs.higherEntry(firstEpoch.getKey)
+
     val faultyEpochs = new util.TreeMap[Integer, lang.Long]()
     faultyEpochs.put(firstEpoch.getKey, firstEpoch.getValue)
     faultyEpochs.put(secondEpoch.getKey, secondEpoch.getValue + 1)
     faultyEpochs.putAll(remoteEpochs.subMap(secondEpoch.getKey, false, remoteEpochs.lastKey(), true))
+
     new RemoteLogSegmentMetadata(
       firstEntry.remoteLogSegmentId(),
       firstEntry.startOffset(),
@@ -1042,9 +1130,14 @@ class RemoteLogManagerTest {
   private def faultyLastEntry(lastEntry: RemoteLogSegmentMetadata): RemoteLogSegmentMetadata = {
     val remoteEpochs = lastEntry.segmentLeaderEpochs()
     val lastEpoch = remoteEpochs.lastEntry()
+
     val faultyEpochs = new util.TreeMap[Integer, lang.Long]()
     faultyEpochs.putAll(remoteEpochs.subMap(remoteEpochs.firstKey(), true, remoteEpochs.lastKey(), false))
-    faultyEpochs.put(lastEpoch.getKey, lastEpoch.getValue - 1)
+
+    // Set this to -1 to simulate the case where the remote epoch has a lower start offset than the remote epoch
+    // Avoid the last epoch as it is the active leader epoch and cannot have been an unclean leader election
+    faultyEpochs.put(lastEpoch.getKey - 1, -1)
+
     new RemoteLogSegmentMetadata(
       lastEntry.remoteLogSegmentId(),
       lastEntry.startOffset(),
@@ -1059,8 +1152,8 @@ class RemoteLogManagerTest {
 
   private def listRemoteLogSegmentMetadataWithFaultyRemoteSegments(segmentCount: Int, recordsPerSegment: Int): List[RemoteLogSegmentMetadata] = {
     val correctList = listRemoteLogSegmentMetadata(segmentCount, recordsPerSegment)
-    val firstEntry = correctList(0)
-    val lastEntry = correctList(correctList.length - 1)
+    val firstEntry = correctList.head
+    val lastEntry = correctList.last
     // We want the first leader epoch in the first entry to end higher than the local one
     // and the last leader epoch in the last entry to start lower than the local one.
     // To achieve the first we need to increase the start offset of the second leader epoch


### PR DESCRIPTION
Resolves https://github.com/satishd/kafka/issues/27

This fixes a bug in calculation of size when retention by size is enabled for a topic with remote storage enabled.