### PR TITLE
Fix bug when replica is synced with incorrect (Global)logStartOffset

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1291,11 +1291,11 @@ class Partition(val topicPartition: TopicPartition,
     * @param newOffset The new offset to start the log with
     * @param isFuture True iff the truncation should be performed on the future log of this partition
     */
-  def truncateFullyAndStartAt(newOffset: Long, isFuture: Boolean): Unit = {
+  def truncateFullyAndStartAt(newOffset: Long, isFuture: Boolean, logStartOffset: Option[Long] = None): Unit = {
     // The read lock is needed to prevent the follower replica from being truncated while ReplicaAlterDirThread
     // is executing maybeReplaceCurrentWithFutureReplica() to replace follower replica with the future replica.
     inReadLock(leaderIsrUpdateLock) {
-      logManager.truncateFullyAndStartAt(topicPartition, newOffset, isFuture = isFuture)
+      logManager.truncateFullyAndStartAt(topicPartition, newOffset, isFuture = isFuture, logStartOffset)
     }
   }
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2311,29 +2311,39 @@ class Log(@volatile private var _dir: File,
   }
 
   /**
-   *  Delete all data in the log and start at the new offset
+   * Delete all data in the log and start at the new offset
    *
-   *  @param newOffset The new offset to start the log with
+   * The caller of this function is responsible for providing a value for logStartOffset when it differs from
+   * newLocalLogStartOffset. This would manifest in a scenario when topic has remote log enabled, offsets before the
+   * localLogStartOffset may reside only in the remote log and not in local log. In such cases, the invariant that
+   * logStartOffset = localLogStartOffset does not hold true.
+   *
+   *  @param newLocalLogStartOffset The new offset to start the local log with. This offset becomes the local log start
+   *                                offset after truncation is complete.
+   *  @param logStartOffset Log start offset for the topic. Defaults to value of newLocalLogStartOffset if not set by
+   *                        the caller.
    */
-  def truncateFullyAndStartAt(newOffset: Long): Unit = {
+  def truncateFullyAndStartAt(newLocalLogStartOffset: Long, logStartOffset: Option[Long] = None): Unit = {
     maybeHandleIOException(s"Error while truncating the entire log for $topicPartition in dir ${dir.getParent}") {
-      debug(s"Truncate and start at offset $newOffset")
+      debug(s"Truncate and start at offset $newLocalLogStartOffset")
+
       lock synchronized {
         checkIfMemoryMappedBufferClosed()
         removeAndDeleteSegments(logSegments, asyncDelete = true, LogTruncation)
         addSegment(LogSegment.open(dir,
-          baseOffset = newOffset,
+          baseOffset = newLocalLogStartOffset,
           config = config,
           time = time,
           initFileSize = initFileSize,
           preallocate = config.preallocate))
         leaderEpochCache.foreach(_.clearAndFlush())
-        producerStateManager.truncateFullyAndStartAt(newOffset)
+        producerStateManager.truncateFullyAndStartAt(newLocalLogStartOffset)
 
+        val newStartOffset = logStartOffset getOrElse newLocalLogStartOffset
         completeTruncation(
-          startOffset = newOffset,
-          localLogStartOffset = newOffset,
-          endOffset = newOffset
+          startOffset = newStartOffset,
+          localLogStartOffset = newLocalLogStartOffset,
+          endOffset = newLocalLogStartOffset
         )
       }
     }

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -575,10 +575,13 @@ class LogManager(logDirs: Seq[File],
    * Delete all data in a partition and start the log at the new offset
    *
    * @param topicPartition The partition whose log needs to be truncated
-   * @param newOffset The new offset to start the log with
+   * @param newLocalLogStartOffset The new offset to start the local log with
    * @param isFuture True iff the truncation should be performed on the future log of the specified partition
+   * @param logStartOffset Log start offset for the topic. Note that localLogStartOffset may not be equal to
+   *                        LogStartOffset if the topic has RemoteLogEnabled
    */
-  def truncateFullyAndStartAt(topicPartition: TopicPartition, newOffset: Long, isFuture: Boolean): Unit = {
+  def truncateFullyAndStartAt(topicPartition: TopicPartition, newLocalLogStartOffset: Long, isFuture: Boolean,
+                              logStartOffset: Option[Long] = None): Unit = {
     val log = {
       if (isFuture)
         futureLogs.get(topicPartition)
@@ -591,7 +594,7 @@ class LogManager(logDirs: Seq[File],
       if (!isFuture)
         abortAndPauseCleaning(topicPartition)
       try {
-        log.truncateFullyAndStartAt(newOffset)
+        log.truncateFullyAndStartAt(newLocalLogStartOffset, logStartOffset)
         if (!isFuture)
           maybeTruncateCleanerCheckpointToActiveSegmentBaseOffset(log, topicPartition)
       } finally {

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -82,7 +82,7 @@ abstract class AbstractFetcherThread(name: String,
 
   protected def truncate(topicPartition: TopicPartition, truncationState: OffsetTruncationState): Unit
 
-  protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit
+  protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long, logStartOffset: Option[Long] = None): Unit
 
   protected def buildFetch(partitionMap: Map[TopicPartition, PartitionFetchState]): ResultWithPartitions[Option[ReplicaFetch]]
 

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -211,9 +211,9 @@ class ReplicaAlterLogDirsThread(name: String,
     partition.truncateTo(truncationState.offset, isFuture = true)
   }
 
-  override protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {
+  override protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long, logStartOffset: Option[Long] = None): Unit = {
     val partition = replicaMgr.getPartitionOrException(topicPartition)
-    partition.truncateFullyAndStartAt(offset, isFuture = true)
+    partition.truncateFullyAndStartAt(offset, isFuture = true, logStartOffset)
   }
 
   private def nextReadyPartition(partitionMap: Map[TopicPartition, PartitionFetchState]): Option[(TopicPartition, PartitionFetchState)] = {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -334,9 +334,10 @@ class ReplicaFetcherThread(name: String,
         offsetTruncationState.offset)
   }
 
-  override protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {
+  override protected def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long,
+                                                 logStartOffset: Option[Long] = None): Unit = {
     val partition = replicaMgr.getPartitionOrException(topicPartition)
-    partition.truncateFullyAndStartAt(offset, isFuture = false)
+    partition.truncateFullyAndStartAt(offset, isFuture = false, logStartOffset)
   }
 
   override def fetchEpochEndOffsets(partitions: Map[TopicPartition, EpochData]): Map[TopicPartition, EpochEndOffset] = {
@@ -419,7 +420,7 @@ class ReplicaFetcherThread(name: String,
             val epochs = readLeaderEpochCheckpoint(epochStream)
 
             // Truncate the existing local log before restoring the leader epoch cache and producer snapshots.
-            truncateFullyAndStartAt(partition, leaderLocalLogStartOffset)
+            truncateFullyAndStartAt(partition, leaderLocalLogStartOffset, Some(leaderLogStartOffset))
 
             log.maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented)
             epochs.foreach(epochEntry => {

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -284,7 +284,7 @@ class LogTest {
     val reopened = createLog(logDir, logConfig)
     assertEquals(Some(LogOffsetMetadata(3L)), reopened.producerStateManager.firstUnstableOffset)
 
-    log.truncateTo(reopened)(0L)
+    reopened.truncateTo(0L)
     assertEquals(None, reopened.firstUnstableOffset)
     assertEquals(Map.empty, reopened.producerStateManager.activeProducers)
   }
@@ -326,7 +326,7 @@ class LogTest {
     val reopened = createLog(logDir, logConfig)
     assertEquals(Some(LogOffsetMetadata(3L)), reopened.producerStateManager.firstUnstableOffset)
 
-    log.truncateFullyAndStartAt(reopened)(0L)
+    reopened.truncateFullyAndStartAt(0L)
     assertEquals(None, reopened.firstUnstableOffset)
     assertEquals(Map.empty, reopened.producerStateManager.activeProducers)
   }

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -249,17 +249,6 @@ class LogTest {
 
   @Test
   def testTruncateBelowFirstUnstableOffset(): Unit = {
-    testTruncateBelowFirstUnstableOffset(_.truncateTo)
-  }
-
-  @Test
-  def testTruncateFullyAndStartBelowFirstUnstableOffset(): Unit = {
-    testTruncateBelowFirstUnstableOffset(_.truncateFullyAndStartAt)
-  }
-
-  private def testTruncateBelowFirstUnstableOffset(
-    truncateFunc: Log => (Long => Unit)
-  ): Unit = {
     // Verify that truncation below the first unstable offset correctly
     // resets the producer state. Specifically we are testing the case when
     // the segment position of the first unstable offset is unknown.
@@ -295,7 +284,49 @@ class LogTest {
     val reopened = createLog(logDir, logConfig)
     assertEquals(Some(LogOffsetMetadata(3L)), reopened.producerStateManager.firstUnstableOffset)
 
-    truncateFunc(reopened)(0L)
+    log.truncateTo(reopened)(0L)
+    assertEquals(None, reopened.firstUnstableOffset)
+    assertEquals(Map.empty, reopened.producerStateManager.activeProducers)
+  }
+
+  @Test
+  def testTruncateFullyAndStartBelowFirstUnstableOffset(): Unit = {
+    // Verify that truncation below the first unstable offset correctly
+    // resets the producer state. Specifically we are testing the case when
+    // the segment position of the first unstable offset is unknown.
+
+    val logConfig = LogTest.createLogConfig(segmentBytes = 1024 * 1024)
+    val log = createLog(logDir, logConfig)
+
+    val producerId = 17L
+    val producerEpoch: Short = 10
+    val sequence = 0
+
+    log.appendAsLeader(TestUtils.records(List(
+      new SimpleRecord("0".getBytes),
+      new SimpleRecord("1".getBytes),
+      new SimpleRecord("2".getBytes)
+    )), leaderEpoch = 0)
+
+    log.appendAsLeader(MemoryRecords.withTransactionalRecords(
+      CompressionType.NONE,
+      producerId,
+      producerEpoch,
+      sequence,
+      new SimpleRecord("3".getBytes),
+      new SimpleRecord("4".getBytes)
+    ), leaderEpoch = 0)
+
+    assertEquals(Some(3L), log.firstUnstableOffset)
+
+    // We close and reopen the log to ensure that the first unstable offset segment
+    // position will be undefined when we truncate the log.
+    log.close()
+
+    val reopened = createLog(logDir, logConfig)
+    assertEquals(Some(LogOffsetMetadata(3L)), reopened.producerStateManager.firstUnstableOffset)
+
+    log.truncateFullyAndStartAt(reopened)(0L)
     assertEquals(None, reopened.firstUnstableOffset)
     assertEquals(Map.empty, reopened.producerStateManager.activeProducers)
   }

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -1056,7 +1056,7 @@ class AbstractFetcherThreadTest {
       state.highWatermark = math.min(state.highWatermark, state.logEndOffset)
     }
 
-    override def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {
+    override def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long, newOffset: Option[Long] = None): Unit = {
       val state = replicaPartitionState(topicPartition)
       state.log.clear()
       if (state.rlmEnabled) {


### PR DESCRIPTION
**Scenario**
Leader has a TopicPartition which is partially offloaded to RemoteStorage. This would result in leader having different values for LocalLogStartOffset and (Global)LogStartOffset). When a new replica is created, it tries to sync from the leader at the ReplicaFetcherThread.buildRemoteLogAuxState() function. This function calls truncateFullyAndStartAt which should set the correct offsets for the topicPartitions in the replica.

**Expectation**
LocalLogStartOffset for the replica topic partition should be equal to the LocalLogStartOffset and (Global)LogStartOffset should be equal to (Global)LogStartOffset.

**Reality (bug)**
(Global)LogStartOffset for the replica topic partition is equal to LocalLogStartOffset of the leader. This occurs because the logOffset passed to [Log.truncateFullyAndStartAt](https://github.com/satishd/kafka/blob/2.8.x-tiered-storage/core/src/main/scala/kafka/log/Log.scala#L2340) from [ReplicaFetcherThread.buildRemoteLogAuxState](https://github.com/satishd/kafka/blob/2.8.x-tiered-storage/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala#L422) is incorrect passed as Leader's leaderLocalLogStartOffset instead of leaderLogStartOffset

**Result**
In case the leader goes down, the replica becomes the new leader with an incorrect (Global)LogStartOffset) and hence, consumer will not be able to read valid data stored in RemoteStorage.